### PR TITLE
Add optional query timeout parameter, and improve transaction handling

### DIFF
--- a/db/connection/connection.go
+++ b/db/connection/connection.go
@@ -17,6 +17,7 @@ package connection
 import (
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/ShiftLeftSecurity/gaum/db/logging"
 	"github.com/pkg/errors"
@@ -25,11 +26,12 @@ import (
 // Information contains all required information to create a connection into a db.
 // Copied almost verbatim from https://godoc.org/github.com/jackc/pgx#ConnConfig
 type Information struct {
-	Host     string // host (e.g. localhost) or path to unix domain socket directory (e.g. /private/tmp)
-	Port     uint16
-	Database string
-	User     string
-	Password string
+	Host             string // host (e.g. localhost) or path to unix domain socket directory (e.g. /private/tmp)
+	Port             uint16
+	Database         string
+	User             string
+	Password         string
+	QueryExecTimeout *time.Duration //optionally set the maximum time a query can take to execute
 
 	TLSConfig         *tls.Config // config for TLS connection -- nil disables TLS
 	UseFallbackTLS    bool        // Try FallbackTLSConfig if connecting with TLSConfig fails. Used for preferring TLS, but allowing unencrypted, or vice-versa

--- a/db/errors/errors.go
+++ b/db/errors/errors.go
@@ -18,3 +18,12 @@ import pkgErrors "github.com/pkg/errors"
 
 // ErrNoRows should be returned when a query that is supposed to yield results does not.
 var ErrNoRows = pkgErrors.New("no rows in result set")
+
+// NoTX is encountered when an operation is done that assumes a transaction exists, but isn't present
+var NoTX = pkgErrors.New("transaction does not exist")
+
+// NoDB is encountered when an operation is preformed without a valid transaction or connection to the DB
+var NoDB = pkgErrors.New("neither transaction or database connection exists")
+
+// AlreadyInTX is encountered when one attempts to start a transaction within a transaction, recursive transactions are not supported at this time.
+var AlreadyInTX = pkgErrors.New("cannot begin a transaction within a transaction")


### PR DESCRIPTION
### Motivation

Just looking over the code (and `jackc/pgx`) for upcoming project. A few nit picks, but nothing massive.

### Summery

* Improved `nil` handling with the whole `tx` vs `conn`, and the leap of faith stuff.
* Added the ability for queries to have a configurable timeout, to avoid corner cases were we are indefinitely blocked on external DB oddities (or extremely long queries). 
* Ensure that `Begin()` will return an error if called on an existing transaction. This is a rather important change, a lot of DB's support recursive transactions (literally transactions in transactions _inception horn_). By returning the existing transaction handle on `Begin()` call it creates the illusion this is supported, when it isn't. 