### PR TITLE
Order By Operator

### DIFF
--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -443,12 +443,12 @@ func (ec *ExpresionChain) OuterJoin(expr, on string, args ...interface{}) *Expre
 // OrderBy adds a 'ORDER BY' to the 'ExpresionChain' and returns the same chan to facilitate
 // further chaining.
 // THIS DOES NOT CREATE A COPY OF THE CHAIN, IT MUTATES IN PLACE.
-func (ec *ExpresionChain) OrderBy(expr string, args ...interface{}) *ExpresionChain {
+func (ec *ExpresionChain) OrderBy(order *OrderByOperator) *ExpresionChain {
 	ec.append(
 		querySegmentAtom{
 			segment:   sqlOrder,
-			expresion: expr,
-			arguments: args,
+			expresion: order.String(),
+			arguments: nil,
 			sqlBool:   SQLNothing,
 		})
 	return ec

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -149,9 +149,9 @@ func TestExpresionChain_Render(t *testing.T) {
 				AndWhere("field1 > ?", 1).
 				AndWhere("field2 = ?", 2).
 				AndWhere("field3 > ?", "pajarito").
-				OrderBy("field2, field3").
+				OrderBy(Asc("field2").Asc("field3")).
 				Join("another_convenient_table", "pirulo = ?", "unpirulo"),
-			want:     "SELECT field1, field2, field3 FROM convenient_table JOIN another_convenient_table ON pirulo = $1 WHERE field1 > $2 AND field2 = $3 AND field3 > $4 ORDER BY field2, field3",
+			want:     "SELECT field1, field2, field3 FROM convenient_table JOIN another_convenient_table ON pirulo = $1 WHERE field1 > $2 AND field2 = $3 AND field3 > $4 ORDER BY field2 ASC, field3 ASC",
 			wantArgs: []interface{}{"unpirulo", 1, 2, "pajarito"},
 			wantErr:  false,
 		},

--- a/db/chain/orderby.go
+++ b/db/chain/orderby.go
@@ -1,0 +1,101 @@
+//    Copyright 2018 Horacio Duran <horacio@shiftleft.io>, ShiftLeft Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package chain
+
+// OrderByOperator unifies the `Asc` and `Desc` functions
+type OrderByOperator struct {
+	others    *OrderByOperator
+	direction bool
+	data      []string
+}
+
+// Asc declares OrderBy ascending, so least to greatest
+func Asc(columns ...string) *OrderByOperator {
+	return &OrderByOperator{
+		direction: false,
+		data:      columns,
+	}
+}
+
+// Desc declares OrderBy descending, or greatest to least
+func Desc(columns ...string) *OrderByOperator {
+	return &OrderByOperator{
+		direction: true,
+		data:      columns,
+	}
+}
+
+// Asc allows for complex chained OrderBy clauses
+func (o *OrderByOperator) Asc(columns ...string) *OrderByOperator {
+	// walk singly linked list to update others
+	others := o.others
+	for {
+		if others != nil {
+			others = o.others
+		} else {
+			break
+		}
+	}
+	others.others = Asc(columns...)
+}
+
+// Desc allows for complex chained OrderBy clauses
+func (o *OrderByOperator) Desc(columns ...string) *OrderByOperator {
+	// walk singly linked list to update the last item
+	others := o.others
+	for {
+		if others != nil {
+			others = o.others
+		} else {
+			break
+		}
+	}
+	others.others = Desc(columns...)
+}
+
+// String converts the operator to a string
+func (o *OrderByOperator) String() string {
+
+	// guard to simply recursion of walking
+	// the internal linked list
+	if o == nil ||
+		(o != nil && len(o.data) == 0) {
+		return ""
+	}
+
+	var way string
+	if direction {
+		way = "DESC"
+	} else {
+		way = "ASC"
+	}
+
+	var section string
+	if len(o.data) == 1 {
+		section = fmt.Sprintf("%s %s", o.data[0], way)
+	} else {
+		var fields []string
+		for _, column := range o.data {
+			fields = append(fields, fmt.Sprintf("%s %s", column, way))
+		}
+		section = strings.Join(fields, ", ")
+	}
+
+	internal := o.others.String()
+	if internal == "" {
+		return section
+	}
+	return strings.Join([]string{section, internal}, ", ")
+}

--- a/db/chain/orderby.go
+++ b/db/chain/orderby.go
@@ -90,6 +90,9 @@ func (o *OrderByOperator) String() string {
 
 	var fields []string
 	for _, column := range o.data {
+		if column == "" {
+			continue
+		}
 		fields = append(fields, fmt.Sprintf("%s %s", column, way))
 	}
 

--- a/db/chain/orderby_test.go
+++ b/db/chain/orderby_test.go
@@ -175,6 +175,18 @@ func TestSerializeMixed(t *testing.T) {
 			orderBy: Desc("hello").Asc("world", "test"),
 			output:  "hello DESC, world ASC, test ASC",
 		},
+		{
+			orderBy: Desc("hello").Asc("").Asc("test"),
+			output:  "hello DESC, test ASC",
+		},
+		{
+			orderBy: Desc("hello", "").Asc("test"),
+			output:  "hello DESC, test ASC",
+		},
+		{
+			orderBy: Desc("hello").Asc("", "test"),
+			output:  "hello DESC, test ASC",
+		},
 	}
 
 	for _, aTest := range tests {

--- a/db/chain/orderby_test.go
+++ b/db/chain/orderby_test.go
@@ -180,11 +180,23 @@ func TestSerializeMixed(t *testing.T) {
 			output:  "hello DESC, test ASC",
 		},
 		{
+			orderBy: Desc("hello").Desc("").Asc("test"),
+			output:  "hello DESC, test ASC",
+		},
+		{
 			orderBy: Desc("hello", "").Asc("test"),
 			output:  "hello DESC, test ASC",
 		},
 		{
 			orderBy: Desc("hello").Asc("", "test"),
+			output:  "hello DESC, test ASC",
+		},
+		{
+			orderBy: Desc("hello").Desc().Asc("test"),
+			output:  "hello DESC, test ASC",
+		},
+		{
+			orderBy: Desc("hello").Asc().Asc("test"),
 			output:  "hello DESC, test ASC",
 		},
 	}

--- a/db/chain/orderby_test.go
+++ b/db/chain/orderby_test.go
@@ -1,0 +1,185 @@
+//    Copyright 2018 Horacio Duran <horacio@shiftleft.io>, ShiftLeft Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package chain
+
+import (
+	"fmt"
+	//"strings"
+	"testing"
+)
+
+func TestAscConstruction(t *testing.T) {
+
+	fieldValue := "my_field"
+	operation := Asc(fieldValue)
+
+	if operation.others != nil {
+		t.Fatal("Asc() should not by default populate the others field")
+	}
+	if operation.direction {
+		t.Fatal("Asc() should set direction to false")
+	}
+	if len(operation.data) != 1 {
+		t.Fatal("Asc() when give 1 field, should only populate 1 item")
+	}
+	if operation.data[0] != fieldValue {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", fieldValue, operation.data[0])
+	}
+
+	value := operation.String()
+	result := fmt.Sprintf("%s ASC", fieldValue)
+	if value != result {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", result, value)
+	}
+}
+
+func TestDescConstruct(t *testing.T) {
+
+	fieldValue := "my_field"
+	operation := Desc(fieldValue)
+
+	if operation.others != nil {
+		t.Fatal("Desc() should not by default populate the others field")
+	}
+	if !operation.direction {
+		t.Fatal("Desc() should set direction to true")
+	}
+	if len(operation.data) != 1 {
+		t.Fatal("Desc() when give 1 field, should only populate 1 item")
+	}
+	if operation.data[0] != fieldValue {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", fieldValue, operation.data[0])
+	}
+
+	value := operation.String()
+	result := fmt.Sprintf("%s DESC", fieldValue)
+	if value != result {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", result, value)
+	}
+}
+
+func TestDescConstructMultiple(t *testing.T) {
+
+	fieldValue0 := "my_field"
+	fieldValue1 := "my_other_field"
+	operation := Desc(fieldValue0, fieldValue1)
+
+	if operation.others != nil {
+		t.Fatal("Desc() should not by default populate the others field")
+	}
+	if !operation.direction {
+		t.Fatal("Desc() should set direction to true")
+	}
+	if len(operation.data) != 2 {
+		t.Fatal("Desc() when give 2 fields, should only populate 2 item")
+	}
+	if operation.data[0] != fieldValue0 {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", fieldValue0, operation.data[0])
+	}
+	if operation.data[1] != fieldValue1 {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", fieldValue1, operation.data[1])
+	}
+
+	value := operation.String()
+	result := fmt.Sprintf("%s DESC, %s DESC", fieldValue0, fieldValue1)
+	if value != result {
+		t.Fatalf("Expected value:(%s) Found value:(%s)", result, value)
+	}
+}
+
+func TestAppendOperation(t *testing.T) {
+
+	fieldValue0 := "my_field"
+	fieldValue1 := "my_other_field"
+	fieldValue2 := "another_field"
+
+	operation0 := Desc(fieldValue0)
+	operation1 := Desc(fieldValue1)
+	operation2 := Desc(fieldValue2)
+
+	if operation0.others != nil {
+		t.Fatal("only chaining should modify others")
+	}
+	if operation1.others != nil {
+		t.Fatal("only chaining should modify others")
+	}
+	if operation2.others != nil {
+		t.Fatal("only chaining should modify others")
+	}
+
+	// append stuff
+	operation0.append(operation1)
+	operation0.append(operation2)
+	if operation0.others == nil {
+		t.Fatal("chaining operators should modify others")
+	}
+	if operation0.others.others == nil {
+		t.Fatal("chaining operators should modify others")
+	}
+
+	// check everything is in the right place
+	if operation0.others != operation1 {
+		t.Fatal("chaining operators should modify others")
+	}
+	if operation0.others.others != operation2 {
+		t.Fatal("chaining operators should modify others")
+	}
+
+	// build an output
+	// since everything is DESC we should be good to go
+	operationTest := Desc(fieldValue0, fieldValue1, fieldValue2)
+	operationTestString := operationTest.String()
+	operation0TestString := operation0.String()
+	if operation0TestString != operationTestString {
+		t.Fatalf("Expected these values will be identical. A:(%s) B:(%s)", operation0TestString, operationTestString)
+	}
+}
+
+func TestSerializeMixed(t *testing.T) {
+
+	type testData struct {
+		orderBy *OrderByOperator
+		output  string
+	}
+
+	tests := []testData{
+		{
+			orderBy: Desc("hello").Asc("world"),
+			output:  "hello DESC, world ASC",
+		},
+		{
+			orderBy: Desc("hello", "world").Asc("test"),
+			output:  "hello DESC, world DESC, test ASC",
+		},
+		{
+			orderBy: Desc("hello").Desc("world").Asc("test"),
+			output:  "hello DESC, world DESC, test ASC",
+		},
+		{
+			orderBy: Desc("hello").Asc("world").Asc("test"),
+			output:  "hello DESC, world ASC, test ASC",
+		},
+		{
+			orderBy: Desc("hello").Asc("world", "test"),
+			output:  "hello DESC, world ASC, test ASC",
+		},
+	}
+
+	for _, aTest := range tests {
+		if aTest.output != aTest.orderBy.String() {
+			t.Fatalf("Expected:(%s) Found:(%s)", aTest.output, aTest.orderBy.String())
+		}
+	}
+}


### PR DESCRIPTION
### Summery

Introduces the type `OrderByOperator` and insures the `OrderBy()` operator in `chain` will only accept that.

This is a _minor_ breaking change, but it enforces correctness at compile time which at least in my opinion is likely the better route.

### Motivation

I wanted to use this for an internal table. 

### Short Comings

So this won't support full conditional `OrderBy`, especially with interior switch statements. Which while a part of the SQL standard I don't this is used very often, it can likely be shoe-horned in down the road if needed as the `OrderByOperator` just calls `String()` in `OrderBy` so we can build a whole universe for `OrderBy` if necessary. 

### Testing

* Added tests to give _close too_ 100% coverage for the `chain/orderby.go` file
* Modified the `chain/chain_test.go` file to fit the interface.
* `go test .` passes so I think we're golden?
