### PR TITLE
Handle `nil` as `NULL`

### DIFF
--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -301,6 +301,8 @@ func (ec *ExpresionChain) Insert(insertPairs map[string]interface{}) *ExpresionC
 
 // Update set fields/values for updates.
 // THIS DOES NOT CREATE A COPY OF THE CHAIN, IT MUTATES IN PLACE.
+//
+// NOTE: values of `nil` will be treated as `NULL`
 func (ec *ExpresionChain) Update(expr string, args ...interface{}) *ExpresionChain {
 	ec.mainOperation = &querySegmentAtom{
 		segment:   sqlUpdate,
@@ -313,6 +315,8 @@ func (ec *ExpresionChain) Update(expr string, args ...interface{}) *ExpresionCha
 
 // UpdateMap set fields/values for updates but does so from a map of key/value.
 // THIS DOES NOT CREATE A COPY OF THE CHAIN, IT MUTATES IN PLACE.
+//
+// NOTE: values of `nil` will be treated as `NULL`
 func (ec *ExpresionChain) UpdateMap(exprMap map[string]interface{}) *ExpresionChain {
 	exprParts := []string{}
 	args := []interface{}{}
@@ -482,8 +486,21 @@ func extract(ec *ExpresionChain, seg sqlSegment) []querySegmentAtom {
 // done with a finished query and requires the args as they depend on the position of the
 // already rendered query, it does some consistency control and finally expands `(?)`.
 func marksToPlaceholders(q string, args []interface{}) (string, []interface{}, error) {
+
+	// assume a nill pointer is a null
+	// this is hacky, but it should work
+	otherArgs := make([]interface{}, len(args))
+	for index, arg := range args {
+		if arg == nil {
+			otherArgs[index] = "NULL"
+		} else {
+			otherArgs[index] = arg
+		}
+	}
+
 	// TODO: make this a bit less ugly
 	// TODO: identify escaped questionmarks
+	// TODO: use an actual parser <3
 	queryWithArgs := ""
 	argCounter := 1
 	argPositioner := 0

--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -497,6 +497,7 @@ func marksToPlaceholders(q string, args []interface{}) (string, []interface{}, e
 			otherArgs[index] = arg
 		}
 	}
+	args = otherArgs
 
 	// TODO: make this a bit less ugly
 	// TODO: identify escaped questionmarks

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -213,6 +213,18 @@ func TestExpresionChain_Render(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "basic update with where and join",
+			chain: (&ExpresionChain{}).Update("field1 = ?, field3 = ?", "value2", nil).
+				Table("convenient_table").
+				AndWhere("field1 > ?", 1).
+				AndWhere("field2 = ?", 2).
+				AndWhere("field3 > ?", "pajarito").
+				Join("another_convenient_table", "pirulo = ?", "unpirulo"),
+			want:     "UPDATE convenient_table SET field1 = $1, field3 = $2 JOIN another_convenient_table ON pirulo = $3 WHERE field1 > $4 AND field2 = $5 AND field3 > $6",
+			wantArgs: []interface{}{"value2", "NULL", "unpirulo", 1, 2, "pajarito"},
+			wantErr:  false,
+		},
+		{
 			name: "basic update with where and join but using map",
 			chain: (&ExpresionChain{}).UpdateMap(map[string]interface{}{"field1": "value2", "field3": 9}).
 				Table("convenient_table").

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -127,6 +127,14 @@ func TestExpresionChain_Render(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "basic insert with nulls",
+			chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": nil}).
+				Table("convenient_table"),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3)",
+			wantArgs: []interface{}{"value1", 2, "NULL"},
+			wantErr:  false,
+		},
+		{
 			name: "basic insert with conflict on column",
 			chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
 				Table("convenient_table").Conflict("id", ConflictActionNothing),
@@ -140,6 +148,14 @@ func TestExpresionChain_Render(t *testing.T) {
 				Table("convenient_table").Conflict(Constraint("id"), ConflictActionNothing),
 			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
 			wantArgs: []interface{}{"value1", 2, "blah"},
+			wantErr:  false,
+		},
+		{
+			name: "basic insert with conflict on constraint with nulls",
+			chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": nil, "field3": "blah"}).
+				Table("convenient_table").Conflict(Constraint("id"), ConflictActionNothing),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
+			wantArgs: []interface{}{"value1", "NULL", "blah"},
 			wantErr:  false,
 		},
 		{


### PR DESCRIPTION
### Motivation

I'm lazy and I don't want to put conditional into my query generation code to guard against `nil` before passing stuff to the SQL generator.

### Summery

Ensure's that `nil` arguments passed to the ORM are treated as `"NULL"`

### Changes

A few

### Testing

I updated `chain_test`

and `go test .` passed