### PR TITLE
Conflict Resolution and Returning Clauses

### DIFF
--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -27,7 +27,7 @@ import (
 
 // NewExpresionChain returns a new instance of ExpresionChain hooked to the passed DB
 func NewExpresionChain(db connection.DB) *ExpresionChain {
-	return &ExpresionChain{db: db, conflict: map[string]string{}}
+	return &ExpresionChain{db: db}
 }
 
 // ExpresionChain holds all the atoms for the SQL expresions that make a query and allows to chain
@@ -43,7 +43,7 @@ type ExpresionChain struct {
 
 	set string
 
-	conflict map[string]string
+	conflict *OnConflict
 
 	db connection.DB
 }
@@ -220,23 +220,35 @@ func (ec *ExpresionChain) Delete() *ExpresionChain {
 	return ec
 }
 
-// ConflictAction represents a possible conflict resolution action.
-type ConflictAction string
-
-const (
-	// ConflictActionNothing represents a nil action on conflict
-	ConflictActionNothing ConflictAction = "NOTHING"
-)
-
 // Conflict will add a "ON CONFLICT" clause at the end of the query if the main operation
 // is an INSERT.
-// This requires a constraint or field name because I really want to be explicit when things
-// are to be ignored.
-func (ec *ExpresionChain) Conflict(constraint string, action ConflictAction) *ExpresionChain {
-	if ec.conflict == nil {
-		ec.conflict = map[string]string{}
+func (ec *ExpresionChain) OnConflict(clause func(*OnConflict)) *ExpresionChain {
+	if ec.conflict != nil {
+		panic("only 1 ON CONFLICT clause can be associated per statement")
 	}
-	ec.conflict[constraint] = string(action)
+	ec.conflict = &OnConflict{}
+	clause(ec.conflict)
+	return ec
+}
+
+// RecursiveQuery is a nice little boi to make writing really string SQL actually pleasent
+type RecursiveQuery func(*ExpresionChain)
+
+// Returning will add an "RETURNING" clause at the end of the query if the main operation
+// is an INSERT.
+func (ec *ExpresionChain) Returning(query RecursiveQuery) *ExpresionChain {
+	localChain := ExpresionChain{}
+	query(&localChain)
+	sql, args, err := localChain.render(true)
+	if err != nil {
+		panic(errors.Wrap(err, "failed to render recursive query").Error())
+	}
+	ec.append(
+		querySegmentAtom{
+			segment:   sqlReturning,
+			expresion: "RETURNING " + sql,
+			arguments: args,
+		})
 	return ec
 }
 
@@ -502,6 +514,7 @@ func marksToPlaceholders(q string, args []interface{}) (string, []interface{}, e
 	// TODO: make this a bit less ugly
 	// TODO: identify escaped questionmarks
 	// TODO: use an actual parser <3
+	// TODO: structure query segments around SQL-Standard AST
 	queryWithArgs := ""
 	argCounter := 1
 	argPositioner := 0
@@ -544,6 +557,8 @@ func (ec *ExpresionChain) renderInsert(raw bool) (string, []interface{}, error) 
 	for i := range ec.mainOperation.arguments {
 		placeholders[i] = "?"
 	}
+
+	// build insert
 	args := make([]interface{}, 0)
 	args = append(args, ec.mainOperation.arguments...)
 	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
@@ -551,17 +566,28 @@ func (ec *ExpresionChain) renderInsert(raw bool) (string, []interface{}, error) 
 		ec.mainOperation.expresion,
 		strings.Join(placeholders, ", "))
 
-	conflicts := []string{}
-	for k, v := range ec.conflict {
-		if v == "" {
+	// render conflict
+	conflict, conflictArgs := ec.conflict.render()
+	if conflict != "" {
+		query += " " + conflict
+	}
+
+	// operationally do something with it
+	if len(conflictArgs) > 0 {
+		args = append(args, conflictArgs...)
+	}
+
+	// look for clauses we can handle
+	for _, segment := range ec.segments {
+		// skip all that stuff we can't handle
+		if segment.segment != sqlReturning {
 			continue
 		}
-		// TODO make parentheses be magic
-		conflicts = append(conflicts,
-			fmt.Sprintf("ON CONFLICT %s DO %s", k, v))
-	}
-	if len(conflicts) > 0 {
-		query += " " + strings.Join(conflicts, ", ")
+		query += " " + segment.expresion
+		// add arguments
+		if len(segment.arguments) > 0 {
+			args = append(args, segment.arguments...)
+		}
 	}
 
 	if !raw {
@@ -599,17 +625,28 @@ func (ec *ExpresionChain) renderInsertMulti(raw bool) (string, []interface{}, er
 		ec.mainOperation.expresion,
 		strings.Join(values, ", "))
 
-	conflicts := []string{}
-	for k, v := range ec.conflict {
-		if v == "" {
+	// render conflict
+	conflict, conflictArgs := ec.conflict.render()
+	if conflict != "" {
+		query += " " + conflict
+	}
+
+	// operationally do something with it
+	if len(conflictArgs) > 0 {
+		args = append(args, conflictArgs...)
+	}
+
+	// look for clauses we can handle
+	for _, segment := range ec.segments {
+		// skip all that stuff we can't handle
+		if segment.segment != sqlReturning {
 			continue
 		}
-		// TODO make parentheses be magic
-		conflicts = append(conflicts,
-			fmt.Sprintf("ON CONFLICT %s DO %s", k, v))
-	}
-	if len(conflicts) > 0 {
-		query += " " + strings.Join(conflicts, ", ")
+		query += " " + segment.expresion
+		// add arguments
+		if len(segment.arguments) > 0 {
+			args = append(args, segment.arguments...)
+		}
 	}
 
 	if !raw {
@@ -675,8 +712,8 @@ func (ec *ExpresionChain) render(raw bool) (string, []interface{}, error) {
 	if ec.mainOperation == nil {
 		return "", nil, errors.Errorf("missing main operation to perform on the db")
 	}
-	// INSERT
 	switch ec.mainOperation.segment {
+	// INSERT
 	case sqlInsert:
 		// Too much of a special cookie for the general case.
 		return ec.renderInsert(raw)
@@ -774,17 +811,14 @@ func (ec *ExpresionChain) render(raw bool) (string, []interface{}, error) {
 		query += strings.Join(orderCriteria, ", ")
 	}
 
-	// LIMIT and OFFSET only make sense in SELECT, I think.
-	if ec.mainOperation.segment == sqlSelect {
-		if ec.limit != nil {
-			query += " LIMIT " + ec.limit.expresion
-			args = append(args, ec.limit.arguments...)
-		}
+	if ec.limit != nil {
+		query += " LIMIT " + ec.limit.expresion
+		args = append(args, ec.limit.arguments...)
+	}
 
-		if ec.offset != nil {
-			query += " OFFSET " + ec.offset.expresion
-			args = append(args, ec.offset.arguments...)
-		}
+	if ec.offset != nil {
+		query += " OFFSET " + ec.offset.expresion
+		args = append(args, ec.offset.arguments...)
 	}
 
 	if !raw {

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -136,28 +136,80 @@ func TestExpresionChain_Render(t *testing.T) {
 		},
 		{
 			name: "basic insert with conflict on column",
-			chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
-				Table("convenient_table").Conflict("id", ConflictActionNothing),
-			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT id DO NOTHING",
+			chain: (&ExpresionChain{}).
+				Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
+				Table("convenient_table").
+				OnConflict(func(c *OnConflict) {
+					c.OnColumn("field2").DoNothing()
+				}),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ( field2 ) DO NOTHING",
+			wantArgs: []interface{}{"value1", 2, "blah"},
+			wantErr:  false,
+		},
+		{
+			name: "advanced insert with conflict on column",
+			chain: (&ExpresionChain{}).
+				Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
+				Table("convenient_table").
+				OnConflict(func(c *OnConflict) {
+					c.OnColumn("field2", "field3").DoNothing()
+				}),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ( field2, field3 ) DO NOTHING",
 			wantArgs: []interface{}{"value1", 2, "blah"},
 			wantErr:  false,
 		},
 		{
 			name: "basic insert with conflict on constraint",
-			chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
-				Table("convenient_table").Conflict(Constraint("id"), ConflictActionNothing),
+			chain: (&ExpresionChain{}).
+				Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
+				Table("convenient_table").
+				OnConflict(func(c *OnConflict) {
+					c.OnConstraint("id").DoNothing()
+				}),
 			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
 			wantArgs: []interface{}{"value1", 2, "blah"},
 			wantErr:  false,
 		},
 		{
-			name: "basic insert with conflict on constraint with nulls",
-			chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": nil, "field3": "blah"}).
-				Table("convenient_table").Conflict(Constraint("id"), ConflictActionNothing),
-			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
-			wantArgs: []interface{}{"value1", "NULL", "blah"},
+			name: "complex insert with an update to default clause",
+			chain: (&ExpresionChain{}).
+				Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "foo"}).
+				Table("convenient_table").
+				OnConflict(func(c *OnConflict) {
+					c.OnConstraint("id").DoUpdate().Set("field2", 4, "field3", "bar")
+				}),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO UPDATE SET field2 = $4, field3 = $5",
+			wantArgs: []interface{}{"value1", 2, "foo", 4, "bar"},
 			wantErr:  false,
 		},
+		{
+			name: "NOW THIS IS PODRACING!! Upsert WITH returning data",
+			chain: (&ExpresionChain{}).
+				Insert(map[string]interface{}{"field1": "value1", "field2": 2, "field3": "blah"}).
+				Table("convenient_table").
+				OnConflict(func(c *OnConflict) {
+					c.OnConstraint("id").DoUpdate().Set("field2", 2)
+				}).
+				Returning(func(ec *ExpresionChain) {
+					ec.
+						Select("field1", "field2", "field3").
+						Table("convenient_table").
+						AndWhere("field3 = ?", "blah")
+				}),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO UPDATE SET field2 = $4 RETURNING SELECT field1, field2, field3 FROM convenient_table WHERE field3 = $5",
+			wantArgs: []interface{}{"value1", 2, "blah", 2, "blah"},
+			wantErr:  false,
+		},
+		/*
+			{
+				name: "basic insert with conflict on constraint with nulls",
+				chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": nil, "field3": "blah"}).
+					Table("convenient_table").OnConflict(OnConstraint, "id", DoNothing),
+				want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
+				wantArgs: []interface{}{"value1", "NULL", "blah"},
+				wantErr:  false,
+			},
+		*/
 		{
 			name: "selection with where and join and order by",
 			chain: (&ExpresionChain{}).Select("field1", "field2", "field3").
@@ -305,10 +357,10 @@ func TestExpresionChain_Render(t *testing.T) {
 				return
 			}
 			if got != tt.want {
-				t.Errorf("ExpresionChain.Render() \ngot = %q, \nwant %q", got, tt.want)
+				t.Errorf("ExpresionChain.Render() \ngot %q, \nwant %q", got, tt.want)
 			}
 			if !reflect.DeepEqual(got1, tt.wantArgs) {
-				t.Errorf("ExpresionChain.Render() got1 = %v, want %v", got1, tt.wantArgs)
+				t.Errorf("ExpresionChain.Render() got1 %v, want %v", got1, tt.wantArgs)
 			}
 		})
 	}

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -200,16 +200,18 @@ func TestExpresionChain_Render(t *testing.T) {
 			wantArgs: []interface{}{"value1", 2, "blah", 2, "blah"},
 			wantErr:  false,
 		},
-		/*
-			{
-				name: "basic insert with conflict on constraint with nulls",
-				chain: (&ExpresionChain{}).Insert(map[string]interface{}{"field1": "value1", "field2": nil, "field3": "blah"}).
-					Table("convenient_table").OnConflict(OnConstraint, "id", DoNothing),
-				want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
-				wantArgs: []interface{}{"value1", "NULL", "blah"},
-				wantErr:  false,
-			},
-		*/
+		{
+			name: "basic insert with conflict on constraint with nulls",
+			chain: (&ExpresionChain{}).
+				Insert(map[string]interface{}{"field1": "value1", "field2": nil, "field3": "blah"}).
+				Table("convenient_table").
+				OnConflict(func(c *OnConflict) {
+					c.OnConstraint("id").DoNothing()
+				}),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO NOTHING",
+			wantArgs: []interface{}{"value1", "NULL", "blah"},
+			wantErr:  false,
+		},
 		{
 			name: "selection with where and join and order by",
 			chain: (&ExpresionChain{}).Select("field1", "field2", "field3").

--- a/db/chain/constraint.go
+++ b/db/chain/constraint.go
@@ -1,0 +1,140 @@
+//    Copyright 2018 Horacio Duran <horacio@shiftleft.io>, ShiftLeft Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package chain
+
+import (
+	"strings"
+)
+
+// OnConflict is chained to build `OnConflict` statements
+type OnConflict struct {
+	prefix string
+	action *OnConflictAction
+}
+
+// OnConstraint is used to create an `On CONFLICT ON CONSTRAINT $arg` statement
+func (o *OnConflict) OnConstraint(arg string) *OnConflictAction {
+	o.prefix = strings.Join([]string{"ON", "CONSTRAINT", arg}, " ")
+	o.action = &OnConflictAction{}
+	return o.action
+}
+
+// OnColumn is used to construct `ON CONFLICT ( arg0, arg1, arg2 )`.
+// This allows for build things like `ON COLUMN ( myindex, COLLATE my_other_index )`
+func (o *OnConflict) OnColumn(args ...string) *OnConflictAction {
+	o.prefix = strings.Join([]string{"(", strings.Join(args, ", "), ")"}, " ")
+	o.action = &OnConflictAction{}
+	return o.action
+}
+
+// OnConflictAction is used to limit developer actions
+type OnConflictAction struct {
+	phrase       string
+	operatorList []argList
+}
+
+// DoNothing terminates the `ON CONFLICT` chain
+func (o *OnConflictAction) DoNothing() {
+	o.phrase = "DO NOTHING"
+	o.operatorList = nil
+}
+
+// DoUpdate continues the `ON CONFLICT` chain
+func (o *OnConflictAction) DoUpdate() *OnUpdate {
+	o.phrase = "DO UPDATE SET"
+	o.operatorList = []argList{}
+	return &OnUpdate{operatorList: &o.operatorList}
+}
+
+// OnUpdate is used to limit developer actions
+type OnUpdate struct {
+	operatorList *[]argList
+}
+
+// SetDefault sets a field to a default value.
+// This is useful to build `ON CONFLICT ON CONSTRAINT my_constraint DO UPDATE SET field = DEFAULT`.
+func (o *OnUpdate) SetDefault(column string) *OnUpdate {
+	*o.operatorList = append(*o.operatorList, argList{
+		text: column + " = DEFAULT",
+	})
+	return o
+}
+
+// SetNow is incrediably useful to set `now()` values.
+// For example: `ON CONFLICT ON CONSTRAINT my_constraint DO UPDATE SET time_value = now()`.
+func (o *OnUpdate) SetNow(column string) *OnUpdate {
+	*o.operatorList = append(*o.operatorList, argList{
+		text: column + " = now()",
+	})
+	return o
+}
+
+// Sets a field to a value
+func (o *OnUpdate) Set(args ...interface{}) *OnUpdate {
+	if len(args)%2 != 0 {
+		panic("arguments to `DoUpdate().Set(...)` must be even in length")
+	}
+	var key string
+	for index, arg := range args {
+		if index%2 == 0 {
+			key = arg.(string)
+		} else {
+			*o.operatorList = append(*o.operatorList, argList{
+				text: key + " = ?",
+				data: arg,
+			})
+		}
+	}
+	return o
+}
+
+// argList handles the messy argument collection work
+type argList struct {
+	text string
+	data interface{}
+}
+
+// render handles walking the OnConflict object
+func (o *OnConflict) render() (string, []interface{}) {
+
+	// return early if there is nothing to do
+	if o == nil ||
+		o.prefix == "" ||
+		o.action == nil ||
+		o.action.phrase == "" {
+		return "", nil
+	}
+
+	// start building output
+	var outputArgs []interface{}
+	formatOutput := []string{
+		"ON", "CONFLICT", o.prefix, o.action.phrase,
+	}
+
+	// collect args
+	var localArgs []string
+	for _, arg := range o.action.operatorList {
+		localArgs = append(localArgs, arg.text)
+		if arg.data != nil {
+			outputArgs = append(outputArgs, arg.data)
+		}
+	}
+
+	// build output
+	if len(localArgs) > 0 {
+		formatOutput = append(formatOutput, strings.Join(localArgs, ", "))
+	}
+	return strings.Join(formatOutput, " "), outputArgs
+}

--- a/db/chain/segment.go
+++ b/db/chain/segment.go
@@ -55,6 +55,7 @@ const (
 	sqlFrom      sqlSegment = "FROM"
 	sqlGroup     sqlSegment = "GROUP BY"
 	sqlOrder     sqlSegment = "ORDER BY"
+	sqlReturning sqlSegment = "RETURNING"
 	// SPECIAL CASES
 	sqlInsertMulti sqlSegment = "INSERTM"
 )

--- a/db/chain/terminations.go
+++ b/db/chain/terminations.go
@@ -22,6 +22,9 @@ import (
 
 // QueryIter is a convenience function to run the current chain through the db query with iterator.
 func (ec *ExpresionChain) QueryIter() (connection.ResultFetchIter, error) {
+	if ec.hasErr() {
+		return nil, ec.getErr()
+	}
 	if !ec.queryable() {
 		return func(interface{}) (bool, func(), error) { return false, func() {}, nil },
 			errors.Errorf("cannot invoke query iter with statements other than SELECT, please use Exec")
@@ -36,6 +39,9 @@ func (ec *ExpresionChain) QueryIter() (connection.ResultFetchIter, error) {
 
 // Query is a convenience function to run the current chain through the db query with iterator.
 func (ec *ExpresionChain) Query() (connection.ResultFetch, error) {
+	if ec.hasErr() {
+		return nil, ec.getErr()
+	}
 	if !ec.queryable() {
 		return func(interface{}) error { return nil },
 			errors.Errorf("cannot invoke query with statements other than SELECT, please use Exec")
@@ -50,6 +56,9 @@ func (ec *ExpresionChain) Query() (connection.ResultFetch, error) {
 
 // QueryPrimitive is a convenience function to run the current chain through the db query.
 func (ec *ExpresionChain) QueryPrimitive() (connection.ResultFetch, error) {
+	if ec.hasErr() {
+		return nil, ec.getErr()
+	}
 	if !ec.queryable() {
 		return func(interface{}) error { return nil },
 			errors.Errorf("cannot invoke query for primitives with statements other than SELECT, please use Exec")
@@ -70,6 +79,10 @@ func (ec *ExpresionChain) QueryPrimitive() (connection.ResultFetch, error) {
 
 // Exec executes the chain, works for Insert and Update
 func (ec *ExpresionChain) Exec() (execError error) {
+	if ec.hasErr() {
+		execError = ec.getErr()
+		return
+	}
 	var q string
 	var args []interface{}
 	q, args, execError = ec.Render()
@@ -112,6 +125,9 @@ func (ec *ExpresionChain) Exec() (execError error) {
 // Raw executes the query and tries to scan the result into fields without much safeguard nor
 // intelligence so you will have to put some of your own
 func (ec *ExpresionChain) Raw(fields ...interface{}) error {
+	if ec.hasErr() {
+		return ec.getErr()
+	}
 	if ec.mainOperation.segment != sqlSelect {
 		return errors.Errorf("cannot invoke query with statements other than SELECT, please use Exec")
 	}


### PR DESCRIPTION
### Summery

Support upserts that return data.

### Motivation

Avoiding gorm, and being able to recover `db` generated primary/foreign keys in a single query. 

### Changes

* Created a bunch of stuff around `OnConflict` clauses.
  * I really wish `go` had nicer lambda syntax, so you could more like the scala `OnConflict(_.OnContraint("id"))` but overall it works, correctly and is fairly readable.
* Added support for the `RETURNING` clause for `INSERT`.
  *  _late night telemarketting voice_ Why just insert data when you READ DATA at the same time!

### TODO

1. I need to make sure `postgres` likes the queries we're giving it in these cases. I wrote this while the manual open, but still I have doubts.
2. `Returning` should likely cause problems if not invoked from `Insert` statement, also additional validation should be added so multiple `Returning` clauses aren't added. 
3. We might want `Set(...interface{})` (part of the constraint stuff) to eventually handle a `func(*ExpresionQuery)` at some point, that'll give us a lot of wiggle room for writing crazy recursive queries. 