### PR TITLE
Fix Returning

### DIFF
--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -237,7 +237,7 @@ func (ec *ExpresionChain) OnConflict(clause func(*OnConflict)) *ExpresionChain {
 // is an INSERT.
 func (ec *ExpresionChain) Returning(args ...string) *ExpresionChain {
 	if ec.mainOperation == nil ||
-		(ec.mainOperation.segment != sqlInsert || ec.mainOperation.segment != sqlUpdate) {
+		(ec.mainOperation.segment != sqlInsert && ec.mainOperation.segment != sqlUpdate) {
 		ec.err = append(ec.err, errors.New("Returning is only valid on UPDATE and INSERT statements"))
 	}
 	ec.append(

--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -816,6 +816,17 @@ func (ec *ExpresionChain) render(raw bool) (string, []interface{}, error) {
 		query += strings.Join(orderCriteria, ", ")
 	}
 
+	// RETURNING
+	for _, segment := range ec.segments {
+		if segment.segment != sqlReturning {
+			continue
+		}
+		query += " " + segment.expresion
+		if len(segment.arguments) > 0 {
+			args = append(args, segment.arguments...)
+		}
+	}
+
 	if ec.limit != nil {
 		query += " LIMIT " + ec.limit.expresion
 		args = append(args, ec.limit.arguments...)

--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -236,8 +236,9 @@ func (ec *ExpresionChain) OnConflict(clause func(*OnConflict)) *ExpresionChain {
 // Returning will add an "RETURNING" clause at the end of the query if the main operation
 // is an INSERT.
 func (ec *ExpresionChain) Returning(args ...string) *ExpresionChain {
-	if ec.mainOperation == nil || ec.mainOperation.segment != sqlInsert {
-		ec.err = append(ec.err, errors.New("Returning is only valid on INSERT statements"))
+	if ec.mainOperation == nil ||
+		(ec.mainOperation.segment != sqlInsert || ec.mainOperation.segment != sqlUpdate) {
+		ec.err = append(ec.err, errors.New("Returning is only valid on UPDATE and INSERT statements"))
 	}
 	ec.append(
 		querySegmentAtom{

--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -235,6 +235,10 @@ func (ec *ExpresionChain) OnConflict(clause func(*OnConflict)) *ExpresionChain {
 
 // Returning will add an "RETURNING" clause at the end of the query if the main operation
 // is an INSERT.
+//
+// Please note that `Returning` likely doesn't do what you expect. There are systemic issues
+// with dependencies and `go-lang` standard library that prevent it from operating correctly
+// in many scenarios.
 func (ec *ExpresionChain) Returning(args ...string) *ExpresionChain {
 	if ec.mainOperation == nil ||
 		(ec.mainOperation.segment != sqlInsert && ec.mainOperation.segment != sqlUpdate) {

--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -539,11 +539,11 @@ func marksToPlaceholders(q string, args []interface{}) (string, []interface{}, e
 						argCounter++
 					}
 					queryWithArgs += strings.Join(placeholders, ", ")
-					// specifically avoid `[]byte`
-					break
+				} else {
+					expandedArgs = append(expandedArgs, arg)
+					queryWithArgs += fmt.Sprintf("$%d", argCounter)
+					argCounter++
 				}
-				// handle `[]byte` like everything else
-				fallthrough
 			default:
 				expandedArgs = append(expandedArgs, arg)
 				queryWithArgs += fmt.Sprintf("$%d", argCounter)

--- a/db/chain/chain.go
+++ b/db/chain/chain.go
@@ -351,7 +351,7 @@ func (ec *ExpresionChain) Table(table string) *ExpresionChain {
 
 // From sets the table to be used in the `FROM` expresion.
 // Functionally this is identical to `Table()`, but it makes
-// code more readiable in some circumstances.
+// code more readable in some circumstances.
 // THIS DOES NOT CREATE A COPY OF THE CHAIN, IT MUTATES IN PLACE.
 func (ec *ExpresionChain) From(table string) *ExpresionChain {
 	ec.setTable(table)

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -190,14 +190,9 @@ func TestExpresionChain_Render(t *testing.T) {
 				OnConflict(func(c *OnConflict) {
 					c.OnConstraint("id").DoUpdate().Set("field2", 2)
 				}).
-				Returning(func(ec *ExpresionChain) {
-					ec.
-						Select("field1", "field2", "field3").
-						Table("convenient_table").
-						AndWhere("field3 = ?", "blah")
-				}),
-			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO UPDATE SET field2 = $4 RETURNING SELECT field1, field2, field3 FROM convenient_table WHERE field3 = $5",
-			wantArgs: []interface{}{"value1", 2, "blah", 2, "blah"},
+				Returning("field1", "field2", "field3"),
+			want:     "INSERT INTO convenient_table (field1, field2, field3) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT id DO UPDATE SET field2 = $4 RETURNING field1, field2, field3",
+			wantArgs: []interface{}{"value1", 2, "blah", 2},
 			wantErr:  false,
 		},
 		{

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -278,7 +278,16 @@ func TestExpresionChain_Render(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "basic update with where and join",
+			name: "update with bytea data",
+			chain: (&ExpresionChain{}).Update("field1 = ?", []byte{0xde, 0xed, 0xbe, 0xef}).
+				Table("convenient_table").
+				Returning("*"),
+			want:     "UPDATE convenient_table SET field1 = $1 RETURNING *",
+			wantArgs: []interface{}{[]byte{0xde, 0xed, 0xbe, 0xef}},
+			wantErr:  false,
+		},
+		{
+			name: "basic update with RETURNING",
 			chain: (&ExpresionChain{}).Update("status = ?", 9).
 				Table("convenient_table").
 				AndWhere("value IN (?, ?)", 1, 2).

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -279,6 +279,16 @@ func TestExpresionChain_Render(t *testing.T) {
 		},
 		{
 			name: "basic update with where and join",
+			chain: (&ExpresionChain{}).Update("status = ?", 9).
+				Table("convenient_table").
+				AndWhere("value IN (?, ?)", 1, 2).
+				Returning("*"),
+			want:     "UPDATE convenient_table SET status = $1 WHERE value IN ($2, $3) RETURNING *",
+			wantArgs: []interface{}{9, 1, 2},
+			wantErr:  false,
+		},
+		{
+			name: "basic update with where and join",
 			chain: (&ExpresionChain{}).Update("field1 = ?, field3 = ?", "value2", nil).
 				Table("convenient_table").
 				AndWhere("field1 > ?", 1).

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -255,7 +255,7 @@ func (d *DB) QueryPrimitive(statement string, field string, args ...interface{})
 	}
 	return func(destination interface{}) error {
 		if reflect.TypeOf(destination).Kind() != reflect.Ptr {
-			return errors.Errorf("the passed receiver is not a pointer, connection is still open")
+			return errors.New("YOU NEED TO PASS A *[]T, if you pass a `[]T` or `[]*T` or `T` you'll get this message again")
 		}
 		// TODO add a timer that closes rows if nothing is done.
 		defer rows.Close()
@@ -312,7 +312,7 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 
 	return func(destination interface{}) error {
 		if reflect.TypeOf(destination).Kind() != reflect.Ptr {
-			return errors.Errorf("the passed receiver is not a pointer, connection is still open")
+			return errors.New("YOU NEED TO PASS A `*[]T`, if you pass a `[]T` or `[]*T` or `T` you'll get this message again")
 		}
 		// TODO add a timer that closes rows if nothing is done.
 		defer rows.Close()

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -254,11 +254,11 @@ func (d *DB) QueryPrimitive(statement string, field string, args ...interface{})
 			errors.Wrap(err, "querying database")
 	}
 	return func(destination interface{}) error {
+		defer rows.Close()
 		if reflect.TypeOf(destination).Kind() != reflect.Ptr {
 			return errors.New("YOU NEED TO PASS A *[]T, if you pass a `[]T` or `[]*T` or `T` you'll get this message again")
 		}
 		// TODO add a timer that closes rows if nothing is done.
-		defer rows.Close()
 		var err error
 		reflect.ValueOf(destination).Elem().Set(reflect.MakeSlice(reflect.TypeOf(destination).Elem(), 0, 0))
 
@@ -311,11 +311,11 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 	var fieldMap map[string]reflect.StructField
 
 	return func(destination interface{}) error {
+		defer rows.Close()
 		if reflect.TypeOf(destination).Kind() != reflect.Ptr {
 			return errors.New("YOU NEED TO PASS A `*[]T`, if you pass a `[]T` or `[]*T` or `T` you'll get this message again")
 		}
 		// TODO add a timer that closes rows if nothing is done.
-		defer rows.Close()
 		var err error
 		reflect.ValueOf(destination).Elem().Set(reflect.MakeSlice(reflect.TypeOf(destination).Elem(), 0, 0))
 
@@ -347,7 +347,6 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 					reflect.Map, reflect.Slice,
 				})
 			if err != nil {
-				defer rows.Close()
 				return errors.Wrapf(err, "cant fetch data into %T", destination)
 			}
 
@@ -357,7 +356,6 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 			// Try to fetch the data
 			err = rows.Scan(fieldRecipients...)
 			if err != nil {
-				defer rows.Close()
 				return errors.Wrap(err, "scanning values into recipient, connection was closed")
 			}
 			// Add to the passed slice, this will actually add to an already populated slice if one

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -200,8 +200,11 @@ func (d *DB) QueryIter(statement string, fields []string, args ...interface{}) (
 			sql.ErrNoRows
 	}
 	if len(fields) == 0 {
-		return func(interface{}) (bool, func(), error) { return false, func() {}, nil },
-			errors.New("no fields passed to fetch")
+		fields, err = rows.Columns()
+		if err != nil {
+			return func(interface{}) (bool, func(), error) { return false, func() {}, nil },
+				errors.Wrap(err, "could not fetch field information from query")
+		}
 	}
 	return func(destination interface{}) (bool, func(), error) {
 		var err error
@@ -323,7 +326,10 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 		tod := reflect.TypeOf(destination).Elem().Elem()
 
 		if len(fields) == 0 {
-			return errors.New("no fields passed to fetch")
+			fields, err = rows.Columns()
+			if err != nil {
+				return errors.Wrap(err, "could not fetch field information from query")
+			}
 		}
 
 		for rows.Next() {


### PR DESCRIPTION
I should have RTFM a bit more before authoring that patch. `RETURNING` doesn't allow a full recursive query, but just a list of fields.

The current patch reflects this. 