### PR TITLE
Make sure field names are extracted for keywords.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PSQL := ${PSQL}
+PSQL ?= psql
 export PGPASSWORD="mysecretpassword"
 
 .PHONY: test-postgres

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PSQL ?= psql
 export PGPASSWORD="mysecretpassword"
 
-.PHONY: test-postgres
+.PHONY: test-postgres-pgx
 test-postgres-pgx: clean-docker
 	docker run --name do_test_gaum -p 5469:5432 -e POSTGRES_PASSWORD=$(PGPASSWORD) -d postgres
 	sleep 3
@@ -10,6 +10,7 @@ test-postgres-pgx: clean-docker
 	docker stop do_test_gaum
 	docker rm do_test_gaum
 
+.PHONY: test-postgres-pq
 test-postgres-pq: clean-docker
 	docker run --name do_test_gaum -p 5469:5432 -e POSTGRES_PASSWORD=$(PGPASSWORD) -d postgres
 	sleep 3

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -98,6 +98,15 @@ func TestExpresionChain_Render(t *testing.T) {
 		},
 		{
 			name: "basic selection with distinct",
+			chain: (&ExpresionChain{}).Select(Distinct("field1")).
+				Table("convenient_table").
+				AndWhere("field1 > ?", 1),
+			want:     "SELECT DISTINCT field1 FROM convenient_table WHERE field1 > $1",
+			wantArgs: []interface{}{1},
+			wantErr:  false,
+		},
+		{
+			name: "basic selection with distinct as",
 			chain: (&ExpresionChain{}).Select(As(Distinct("field1"), "renamed")).
 				Table("convenient_table").
 				AndWhere("field1 > ?", 1),

--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -98,10 +98,10 @@ func TestExpresionChain_Render(t *testing.T) {
 		},
 		{
 			name: "basic selection with distinct",
-			chain: (&ExpresionChain{}).Select(Distinct("field1")).
+			chain: (&ExpresionChain{}).Select(As(Distinct("field1"), "renamed")).
 				Table("convenient_table").
 				AndWhere("field1 > ?", 1),
-			want:     "SELECT DISTINCT field1 FROM convenient_table WHERE field1 > $1",
+			want:     "SELECT DISTINCT field1 AS renamed FROM convenient_table WHERE field1 > $1",
 			wantArgs: []interface{}{1},
 			wantErr:  false,
 		},

--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -246,14 +246,14 @@ func testConnector_Distinct(t *testing.T, newDB NewDB) {
 	db := newDB(t)
 
 	ids := []struct {
-		ID int `gaum:"field_name:id"`
+		ID int `gaum:"field_name:renamed"`
 		Description string `gaum:"field_name:description"`
 	}{}
 
 	// Test Multiple row Iterator
 	query := chain.NewExpresionChain(db)
 	prefix := chain.TablePrefix("justforfun")
-	query.Select(chain.Distinct(prefix("id")), prefix("description")).Table("justforfun").OrderBy(chain.Asc("id"))
+	query.Select(chain.As(chain.Distinct(prefix("id")), "renamed"), prefix("description")).Table("justforfun").OrderBy(chain.Asc("id"))
 	fetcher, err := query.Query()
 	if err != nil {
 		t.Errorf("failed to query: %v", err)

--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -47,6 +47,10 @@ func DoTestConnector_Distinct(t *testing.T, newDB NewDB) {
 	testConnector_Distinct(t, newDB)
 }
 
+func DoTestConnector_DistinctAs(t *testing.T, newDB NewDB) {
+	testConnector_DistinctAs(t, newDB)
+}
+
 func DoTestConnector_Raw(t *testing.T, newDB NewDB) {
 	testConnector_Raw(t, newDB)
 }
@@ -246,6 +250,42 @@ func testConnector_Distinct(t *testing.T, newDB NewDB) {
 	db := newDB(t)
 
 	ids := []struct {
+		ID int `gaum:"field_name:id"`
+		Description string `gaum:"field_name:description"`
+	}{}
+
+	// Test Multiple row Iterator
+	query := chain.NewExpresionChain(db)
+	prefix := chain.TablePrefix("justforfun")
+	query.Select(chain.Distinct(prefix("id")), prefix("description")).Table("justforfun").OrderBy(chain.Asc("id"))
+	fetcher, err := query.Query()
+	if err != nil {
+		t.Errorf("failed to query: %v", err)
+	}
+
+	// Debug print query
+	q, args, err := query.Render()
+	if err != nil {
+		t.Errorf("failed to render: %v", err)
+	}
+	t.Logf("will perform query %q", q)
+	t.Logf("with arguments %#v", args)
+
+	err = fetcher(&ids)
+	if err != nil {
+		t.Errorf("failed to fetch data: %v", err)
+	}
+
+	if len(ids) != 10 {
+		t.Logf("expected 10 results got %d", len(ids))
+		t.FailNow()
+	}
+}
+
+func testConnector_DistinctAs(t *testing.T, newDB NewDB) {
+	db := newDB(t)
+
+	ids := []struct {
 		ID int `gaum:"field_name:renamed"`
 		Description string `gaum:"field_name:description"`
 	}{}
@@ -277,7 +317,6 @@ func testConnector_Distinct(t *testing.T, newDB NewDB) {
 		t.FailNow()
 	}
 }
-
 
 func testConnector_Raw(t *testing.T, newDB NewDB) {
 

--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -43,6 +43,10 @@ func DoTestConnector_Query(t *testing.T, newDB NewDB) {
 	testConnector_Query(t, newDB)
 }
 
+func DoTestConnector_Distinct(t *testing.T, newDB NewDB) {
+	testConnector_Distinct(t, newDB)
+}
+
 func DoTestConnector_Raw(t *testing.T, newDB NewDB) {
 	testConnector_Raw(t, newDB)
 }
@@ -237,6 +241,43 @@ func testConnector_Query(t *testing.T, newDB NewDB) {
 	}
 
 }
+
+func testConnector_Distinct(t *testing.T, newDB NewDB) {
+	db := newDB(t)
+
+	ids := []struct {
+		ID int `gaum:"field_name:id"`
+		Description string `gaum:"field_name:description"`
+	}{}
+
+	// Test Multiple row Iterator
+	query := chain.NewExpresionChain(db)
+	prefix := chain.TablePrefix("justforfun")
+	query.Select(chain.Distinct(prefix("id")), prefix("description")).Table("justforfun").OrderBy(chain.Asc("id"))
+	fetcher, err := query.Query()
+	if err != nil {
+		t.Errorf("failed to query: %v", err)
+	}
+
+	// Debug print query
+	q, args, err := query.Render()
+	if err != nil {
+		t.Errorf("failed to render: %v", err)
+	}
+	t.Logf("will perform query %q", q)
+	t.Logf("with arguments %#v", args)
+
+	err = fetcher(&ids)
+	if err != nil {
+		t.Errorf("failed to fetch data: %v", err)
+	}
+
+	if len(ids) != 10 {
+		t.Logf("expected 10 results got %d", len(ids))
+		t.FailNow()
+	}
+}
+
 
 func testConnector_Raw(t *testing.T, newDB NewDB) {
 

--- a/db/postgres/connection_test.go
+++ b/db/postgres/connection_test.go
@@ -60,6 +60,10 @@ func TestConnector_Distinct(t *testing.T) {
 	connection_testing.DoTestConnector_Distinct(t, newDB)
 }
 
+func TestConnector_DistinctAs(t *testing.T) {
+	connection_testing.DoTestConnector_DistinctAs(t, newDB)
+}
+
 func TestConnector_Raw(t *testing.T) {
 	connection_testing.DoTestConnector_Raw(t, newDB)
 }

--- a/db/postgres/connection_test.go
+++ b/db/postgres/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_Distinct(t *testing.T) {
+	connection_testing.DoTestConnector_Distinct(t, newDB)
+}
+
 func TestConnector_Raw(t *testing.T) {
 	connection_testing.DoTestConnector_Raw(t, newDB)
 }

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -60,6 +60,10 @@ func TestConnector_Distinct(t *testing.T) {
 	connection_testing.DoTestConnector_Distinct(t, newDB)
 }
 
+func TestConnector_DistinctAs(t *testing.T) {
+	connection_testing.DoTestConnector_DistinctAs(t, newDB)
+}
+
 func TestConnector_Raw(t *testing.T) {
 	connection_testing.DoTestConnector_Raw(t, newDB)
 }

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_Distinct(t *testing.T) {
+	connection_testing.DoTestConnector_Distinct(t, newDB)
+}
+
 func TestConnector_Raw(t *testing.T) {
 	connection_testing.DoTestConnector_Raw(t, newDB)
 }

--- a/selectparse/selectparse.go
+++ b/selectparse/selectparse.go
@@ -189,10 +189,10 @@ func extractFromKeywordsOrFunc(column string) string {
 		buffer = append(buffer, string(r))
 	}
 	if len(buffer) != 0 && depth == 0 {
-		return strings.Trim(strings.Join(buffer, ""), " ")
+		return extractFromSingleWord(strings.Trim(strings.Join(buffer, ""), " "))
 	}
 	if len(previousToken) != 0 && depth == 0 {
-		return strings.Trim(strings.Join(previousToken, ""), " ")
+		return extractFromSingleWord(strings.Trim(strings.Join(previousToken, ""), " "))
 	}
 
 	return ""


### PR DESCRIPTION
Otherwise fails to run a `SELECT DISTINCT x.y ...` kind of query.