### PR TITLE
Add ExecResult to return RowsAffected by Exec

### DIFF
--- a/db/connection/connection.go
+++ b/db/connection/connection.go
@@ -104,7 +104,7 @@ type DB interface {
 	ERaw(statement string, args []interface{}, fields ...interface{}) error
 	// Exec is intended for queries that do not yield results (data modifiers)
 	Exec(statement string, args ...interface{}) error
-	// ExecResult is intended for queries that modify data and respond with how many rowsaffected.
+	// ExecResult is intended for queries that modify data and respond with how many rows were affected.
 	ExecResult(statement string, args ...interface{}) (int64, error)
 	// EExec is Exec but will use EscapeArgs.
 	EExec(statement string, args ...interface{}) error

--- a/db/connection/connection.go
+++ b/db/connection/connection.go
@@ -104,6 +104,8 @@ type DB interface {
 	ERaw(statement string, args []interface{}, fields ...interface{}) error
 	// Exec is intended for queries that do not yield results (data modifiers)
 	Exec(statement string, args ...interface{}) error
+	// ExecResult is intended for queries that modify data and respond with how many rowsaffected.
+	ExecResult(statement string, args ...interface{}) (int64, error)
 	// EExec is Exec but will use EscapeArgs.
 	EExec(statement string, args ...interface{}) error
 	// BeginTransaction returns a new DB that will use the transaction instead of the basic conn.

--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -15,6 +15,7 @@ package connection_testing
 //    limitations under the License.
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -813,6 +814,27 @@ func testConnector_ExecResult(t *testing.T, newDB NewDB) {
 	}
 	if rowsAffected != 2 {
 		t.Logf("expected 2 row to be affected by update, instead got: %d", rowsAffected)
+		t.FailNow()
+	}
+
+	//test query that does not have rows affected
+	tempTable := "test_exec_result_temp_table"
+	rowsAffected, err = db.ExecResult(fmt.Sprintf("CREATE TABLE %s (id int)", tempTable))
+	if err != nil {
+		t.Logf("create table failed: %v", err)
+		t.FailNow()
+	}
+	if rowsAffected != 0 {
+		t.Logf("expected 0 rows to be affected by create table, instead got: %d", rowsAffected)
+		t.FailNow()
+	}
+	rowsAffected, err = db.ExecResult(fmt.Sprintf("DROP TABLE %s", tempTable))
+	if err != nil {
+		t.Logf("drop table failed: %v", err)
+		t.FailNow()
+	}
+	if rowsAffected != 0 {
+		t.Logf("expected 0 rows to be affected by drop table, instead got: %d", rowsAffected)
 		t.FailNow()
 	}
 }

--- a/db/postgres/connection.go
+++ b/db/postgres/connection.go
@@ -483,7 +483,6 @@ func (d *DB) exec(statement string, args ...interface{}) (pgx.CommandTag, error)
 	if err != nil {
 		return connTag, errors.Wrapf(err, "querying database, obtained %s", connTag)
 	}
-
 	return connTag, nil
 }
 

--- a/db/postgres/connection_test.go
+++ b/db/postgres/connection_test.go
@@ -91,3 +91,7 @@ func TestConnector_QueryPrimitives(t *testing.T) {
 func TestConnector_RegressionReturning(t *testing.T) {
 	connection_testing.DoTestConnector_Regression_Returning(t, newDB)
 }
+
+func TestConnector_ExecResult(t *testing.T) {
+	connection_testing.DoTestConnector_ExecResult(t, newDB)
+}

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -473,7 +473,6 @@ func (d *DB) exec(statement string, args ...interface{}) (sql.Result, error) {
 		defer cancel()
 		if d.tx != nil {
 			connTag, err = d.tx.ExecContext(ctx, statement, args...)
-
 		} else if d.conn != nil {
 			connTag, err = d.conn.ExecContext(ctx, statement, args...)
 		} else {
@@ -491,7 +490,6 @@ func (d *DB) exec(statement string, args ...interface{}) (sql.Result, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "querying database, obtained %s", connTag)
 	}
-
 	return connTag, nil
 }
 

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -447,6 +447,24 @@ func (d *DB) EExec(statement string, args ...interface{}) error {
 
 // Exec will run the statement and expect nothing in return.
 func (d *DB) Exec(statement string, args ...interface{}) error {
+	_, err := d.exec(statement, args...)
+	return err
+}
+
+// ExecResult will run the statement and return the number of rows affected.
+func (d *DB) ExecResult(statement string, args ...interface{}) (int64, error) {
+	connTag, err := d.exec(statement, args...)
+	if err != nil {
+		return 0, err
+	}
+	rowsAffected, err := connTag.RowsAffected()
+	if err != nil {
+		return 0, errors.Wrap(err, "reading rowsAffected from connTag")
+	}
+	return rowsAffected, nil
+}
+
+func (d *DB) exec(statement string, args ...interface{}) (sql.Result, error) {
 	var connTag sql.Result
 	var err error
 
@@ -455,10 +473,11 @@ func (d *DB) Exec(statement string, args ...interface{}) error {
 		defer cancel()
 		if d.tx != nil {
 			connTag, err = d.tx.ExecContext(ctx, statement, args...)
+
 		} else if d.conn != nil {
 			connTag, err = d.conn.ExecContext(ctx, statement, args...)
 		} else {
-			return gaumErrors.NoDB
+			return nil, gaumErrors.NoDB
 		}
 	} else {
 		if d.tx != nil {
@@ -466,13 +485,14 @@ func (d *DB) Exec(statement string, args ...interface{}) error {
 		} else if d.conn != nil {
 			connTag, err = d.conn.Exec(statement, args...)
 		} else {
-			return gaumErrors.NoDB
+			return nil, gaumErrors.NoDB
 		}
 	}
 	if err != nil {
-		return errors.Wrapf(err, "querying database, obtained %s", connTag)
+		return nil, errors.Wrapf(err, "querying database, obtained %s", connTag)
 	}
-	return nil
+
+	return connTag, nil
 }
 
 // BeginTransaction returns a new DB that will use the transaction instead of the basic conn.

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -91,3 +91,7 @@ func TestConnector_QueryPrimitives(t *testing.T) {
 func TestConnector_RegressionReturning(t *testing.T) {
 	connection_testing.DoTestConnector_Regression_Returning(t, newDB)
 }
+
+func TestConnector_ExecResult(t *testing.T) {
+	connection_testing.DoTestConnector_ExecResult(t, newDB)
+}


### PR DESCRIPTION
- Adds ExecResult which returns number of rows affected by Update or Insert.

Testing:
`make test-all` (With additional tests that were added)

