### PR TITLE
bubble up rows.Err() from Query()

### DIFF
--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -49,6 +49,10 @@ func DoTestConnector_QueryReturningWithError(t *testing.T, newDB NewDB) {
 	testConnector_QueryReturningWithError(t, newDB)
 }
 
+func DoTestConnector_QueryNoRows(t *testing.T, newDB NewDB) {
+	testConnector_QueryNoRows(t, newDB)
+}
+
 func DoTestConnector_Distinct(t *testing.T, newDB NewDB) {
 	testConnector_Distinct(t, newDB)
 }
@@ -258,11 +262,8 @@ func testConnector_Query(t *testing.T, newDB NewDB) {
 
 func testConnector_QueryReturningWithError(t *testing.T, newDB NewDB) {
 	db := newDB(t)
-	type InnerRow struct {
-		Id int
-	}
 	type row struct {
-		InnerRow
+		Id          int
 		Description string
 	}
 
@@ -294,7 +295,28 @@ func testConnector_QueryReturningWithError(t *testing.T, newDB NewDB) {
 	} else {
 		t.Error("expected to receive a PgError error, instead got %T, %+v", err, err)
 	}
+}
 
+func testConnector_QueryNoRows(t *testing.T, newDB NewDB) {
+	db := newDB(t)
+	type row struct {
+		Id          int
+		Description string
+	}
+
+	query := chain.NewExpresionChain(db)
+	query.Select("*").AndWhere("id = ?", 99999999).Table("justforfun")
+
+	fetcher, err := query.Query()
+	if err != nil {
+		t.Errorf("failed to query: %v", err)
+	}
+
+	var multiRow []row
+	err = fetcher(&multiRow)
+	if err != nil {
+		t.Error("expected to receive no error, instead got %v", err)
+	}
 }
 
 func testConnector_Distinct(t *testing.T, newDB NewDB) {

--- a/db/postgres/connection.go
+++ b/db/postgres/connection.go
@@ -226,7 +226,7 @@ func (d *DB) QueryIter(statement string, fields []string, args ...interface{}) (
 				"scanning values into recipient, connection was closed")
 		}
 
-		return rows.Next(), rows.Close, nil
+		return rows.Next(), rows.Close, rows.Err()
 	}, nil
 }
 
@@ -291,7 +291,7 @@ func (d *DB) QueryPrimitive(statement string, field string, args ...interface{})
 			// passed, how cool is that?
 			destinationSlice.Set(reflect.Append(destinationSlice, newElemPtr.Elem()))
 		}
-		return nil
+		return rows.Err()
 	}, nil
 }
 
@@ -384,7 +384,7 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 			// passed, how cool is that?
 			destinationSlice.Set(reflect.Append(destinationSlice, newElemPtr.Elem()))
 		}
-		return nil
+		return rows.Err()
 	}, nil
 }
 

--- a/db/postgres/connection_test.go
+++ b/db/postgres/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_QueryReturningWithError(t *testing.T) {
+	connection_testing.DoTestConnector_QueryReturningWithError(t, newDB)
+}
+
 func TestConnector_Distinct(t *testing.T) {
 	connection_testing.DoTestConnector_Distinct(t, newDB)
 }

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -233,7 +233,7 @@ func (d *DB) QueryIter(statement string, fields []string, args ...interface{}) (
 				"scanning values into recipient, connection was closed")
 		}
 
-		return rows.Next(), func() { rows.Close() }, nil
+		return rows.Next(), func() { rows.Close() }, rows.Err()
 	}, nil
 }
 
@@ -298,7 +298,7 @@ func (d *DB) QueryPrimitive(statement string, field string, args ...interface{})
 			// passed, how cool is that?
 			destinationSlice.Set(reflect.Append(destinationSlice, newElemPtr.Elem()))
 		}
-		return nil
+		return rows.Err()
 	}, nil
 }
 
@@ -387,7 +387,7 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 			// passed, how cool is that?
 			destinationSlice.Set(reflect.Append(destinationSlice, newElemPtr.Elem()))
 		}
-		return nil
+		return rows.Err()
 	}, nil
 }
 

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_QueryReturningWithError(t *testing.T) {
+	connection_testing.DoTestConnector_QueryReturningWithError(t, newDB)
+}
+
 func TestConnector_Distinct(t *testing.T) {
 	connection_testing.DoTestConnector_Distinct(t, newDB)
 }

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -60,6 +60,10 @@ func TestConnector_QueryReturningWithError(t *testing.T) {
 	connection_testing.DoTestConnector_QueryReturningWithError(t, newDB)
 }
 
+func TestConnector_QueryNoRows(t *testing.T) {
+	connection_testing.DoTestConnector_QueryNoRows(t, newDB)
+}
+
 func TestConnector_Distinct(t *testing.T) {
 	connection_testing.DoTestConnector_Distinct(t, newDB)
 }


### PR DESCRIPTION
`rows.Err()` in most use cases will be `nil`, but there is an edge case for `Returning` from an `Insert` with a Duplicate Key error that was being swallowed.

Also adds a test for querying "No Rows", which should not return an error (I was worried that we might be swallowing it, and this would introduce a break change, but that does not seem to be the case).