### PR TITLE
scan unknown fields in to noopScanner instead of interface{}

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Horacio Duran <horacio@shiftleft.io>
 William Cody Laeder <cody@shiftleft.io>
+Alex Hornbake <alex@shiftleft.io>

--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -45,6 +45,10 @@ func DoTestConnector_Query(t *testing.T, newDB NewDB) {
 	testConnector_Query(t, newDB)
 }
 
+func DoTestConnector_QueryStar(t *testing.T, newDB NewDB) {
+	testConnector_QueryStar(t, newDB)
+}
+
 func DoTestConnector_QueryReturningWithError(t *testing.T, newDB NewDB) {
 	testConnector_QueryReturningWithError(t, newDB)
 }
@@ -220,6 +224,60 @@ func testConnector_Query(t *testing.T, newDB NewDB) {
 	}
 	t.Logf("will perform query %q", q)
 	t.Logf("with arguments %#v", args)
+
+	var multiRow []row
+	ordinals := []string{
+		"first",
+		"second",
+		"third",
+		"fourth",
+		"fift",
+		"sixt",
+		"seventh",
+		"eight",
+		"ninth",
+		"tenth",
+	}
+	err = fetcher(&multiRow)
+	if err != nil {
+		t.Errorf("failed to fetch data: %v", err)
+	}
+
+	if len(multiRow) != 10 {
+		t.Logf("expected 10 results got %d", len(multiRow))
+		t.FailNow()
+	}
+	for i := 1; i < 11; i++ {
+		t.Logf("Iteration %d", i)
+		oneRowMulti := multiRow[i-1]
+
+		if oneRowMulti.Id != i {
+			t.Logf("row Id is %d expected 1", oneRowMulti.Id)
+			t.FailNow()
+		}
+		if oneRowMulti.Description != ordinals[i-1] {
+			t.Logf("row Description is %q expected %q", oneRowMulti.Description, ordinals[i-1])
+			t.FailNow()
+		}
+
+	}
+
+}
+
+func testConnector_QueryStar(t *testing.T, newDB NewDB) {
+	db := newDB(t)
+	type row struct {
+		Id          int    `gaum:"field_name:id"`
+		Description string `gaum:"field_name:description"`
+	}
+
+	// Test Multiple row Iterator
+	query := chain.NewExpresionChain(db)
+	query.Select("*").Table("justforfun").OrderBy(chain.Asc("id"))
+	fetcher, err := query.Query()
+	if err != nil {
+		t.Errorf("failed to query: %v", err)
+	}
 
 	var multiRow []row
 	ordinals := []string{

--- a/db/postgres/connection_test.go
+++ b/db/postgres/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_QueryStar(t *testing.T) {
+	connection_testing.DoTestConnector_QueryStar(t, newDB)
+}
+
 func TestConnector_QueryReturningWithError(t *testing.T) {
 	connection_testing.DoTestConnector_QueryReturningWithError(t, newDB)
 }

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_QueryStar(t *testing.T) {
+	connection_testing.DoTestConnector_QueryStar(t, newDB)
+}
+
 func TestConnector_QueryReturningWithError(t *testing.T) {
 	connection_testing.DoTestConnector_QueryReturningWithError(t, newDB)
 }

--- a/db/srm/reflection.go
+++ b/db/srm/reflection.go
@@ -15,6 +15,7 @@
 package srm
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"unicode"
@@ -221,9 +222,13 @@ func FieldRecipientsFromType(logger logging.Logger, sqlFields []string,
 // noopScanner implements the Scanner interface and ignores the value
 // this is useful if we do not know what to do with a value.
 // ie. We have asked for "*" and receive some unmapped fields
-type noopScanner struct{}
+type noopScanner struct {
+	field  string
+	logger logging.Logger
+}
 
 func (ns noopScanner) Scan(src interface{}) error {
+	ns.logger.Warn(fmt.Sprintf("ignoring scan (read) of (unmapped) column: %s, value: %+v", ns.field, src))
 	return nil
 }
 
@@ -237,7 +242,7 @@ func FieldRecipientsFromValueOf(logger logging.Logger, sqlFields []string,
 		// TODO, check datatype compatibility or let it burn?
 		fVal, ok := fieldMap[field]
 		if !ok {
-			empty := noopScanner{}
+			empty := noopScanner{logger: logger, field: field}
 			fieldRecipients[i] = empty
 			continue
 		}

--- a/db/srm/reflection.go
+++ b/db/srm/reflection.go
@@ -218,9 +218,12 @@ func FieldRecipientsFromType(logger logging.Logger, sqlFields []string,
 	return FieldRecipientsFromValueOf(logger, sqlFields, fieldMap, vod)
 }
 
-type NoopScanner struct{}
+// noopScanner implements the Scanner interface and ignores the value
+// this is useful if we do not know what to do with a value.
+// ie. We have asked for "*" and receive some unmapped fields
+type noopScanner struct{}
 
-func (ns NoopScanner) Scan(src interface{}) error {
+func (ns noopScanner) Scan(src interface{}) error {
 	return nil
 }
 
@@ -234,7 +237,7 @@ func FieldRecipientsFromValueOf(logger logging.Logger, sqlFields []string,
 		// TODO, check datatype compatibility or let it burn?
 		fVal, ok := fieldMap[field]
 		if !ok {
-			empty := NoopScanner{}
+			empty := noopScanner{}
 			fieldRecipients[i] = empty
 			continue
 		}

--- a/db/srm/reflection.go
+++ b/db/srm/reflection.go
@@ -218,6 +218,12 @@ func FieldRecipientsFromType(logger logging.Logger, sqlFields []string,
 	return FieldRecipientsFromValueOf(logger, sqlFields, fieldMap, vod)
 }
 
+type NoopScanner struct{}
+
+func (ns NoopScanner) Scan(src interface{}) error {
+	return nil
+}
+
 // FieldRecipientsFromValueOf returns an array of pointer to attributes from the passed
 // in reflect.Value.
 func FieldRecipientsFromValueOf(logger logging.Logger, sqlFields []string,
@@ -228,7 +234,7 @@ func FieldRecipientsFromValueOf(logger logging.Logger, sqlFields []string,
 		// TODO, check datatype compatibility or let it burn?
 		fVal, ok := fieldMap[field]
 		if !ok {
-			var empty interface{}
+			empty := NoopScanner{}
 			fieldRecipients[i] = empty
 			continue
 		}

--- a/initial.sql
+++ b/initial.sql
@@ -1,11 +1,11 @@
-CREATE TABLE justforfun (id int, description text, CONSTRAINT therecanbeonlyone UNIQUE (id));
-INSERT INTO justforfun (id, description) VALUES (1, 'first');
-INSERT INTO justforfun (id, description) VALUES (2, 'second');
+CREATE TABLE justforfun (id int, description text, not_used int, CONSTRAINT therecanbeonlyone UNIQUE (id));
+INSERT INTO justforfun (id, description, not_used) VALUES (1, 'first', NULL);
+INSERT INTO justforfun (id, description, not_used) VALUES (2, 'second', 200);
 INSERT INTO justforfun (id, description) VALUES (3, 'third');
 INSERT INTO justforfun (id, description) VALUES (4, 'fourth');
-INSERT INTO justforfun (id, description) VALUES (5, 'fift');
+INSERT INTO justforfun (id, description, not_used) VALUES (5, 'fift', NULL);
 INSERT INTO justforfun (id, description) VALUES (6, 'sixt');
 INSERT INTO justforfun (id, description) VALUES (7, 'seventh');
-INSERT INTO justforfun (id, description) VALUES (8, 'eight');
+INSERT INTO justforfun (id, description, not_used) VALUES (8, 'eight', 800);
 INSERT INTO justforfun (id, description) VALUES (9, 'ninth');
 INSERT INTO justforfun (id, description) VALUES (10, 'tenth');


### PR DESCRIPTION
Hit an edge case where an unmapped struct field with NULL values was causing problems when selecting "*".

This adds a noopScanner that can be used to safely scan an unknown/unmapped field/value to nowhere.