### PR TITLE
Address nillable values Scan

### DIFF
--- a/db/postgres/connection_test.go
+++ b/db/postgres/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_QueryReflection(t *testing.T) {
+	connection_testing.DoTestConnector_QueryReflection(t, newDB)
+}
+
 func TestConnector_QueryStar(t *testing.T) {
 	connection_testing.DoTestConnector_QueryStar(t, newDB)
 }

--- a/db/postgrespq/connection_test.go
+++ b/db/postgrespq/connection_test.go
@@ -56,6 +56,10 @@ func TestConnector_Query(t *testing.T) {
 	connection_testing.DoTestConnector_Query(t, newDB)
 }
 
+func TestConnector_QueryReflection(t *testing.T) {
+	connection_testing.DoTestConnector_QueryReflection(t, newDB)
+}
+
 func TestConnector_QueryStar(t *testing.T) {
 	connection_testing.DoTestConnector_QueryStar(t, newDB)
 }

--- a/initial.sql
+++ b/initial.sql
@@ -1,11 +1,11 @@
-CREATE TABLE justforfun (id int, description text, not_used int, CONSTRAINT therecanbeonlyone UNIQUE (id));
+CREATE TABLE justforfun (id int, description text, not_used text, not_used_time TIMESTAMP, CONSTRAINT therecanbeonlyone UNIQUE (id));
 INSERT INTO justforfun (id, description, not_used) VALUES (1, 'first', NULL);
-INSERT INTO justforfun (id, description, not_used) VALUES (2, 'second', 200);
+INSERT INTO justforfun (id, description, not_used) VALUES (2, 'second', 'meh');
 INSERT INTO justforfun (id, description) VALUES (3, 'third');
 INSERT INTO justforfun (id, description) VALUES (4, 'fourth');
 INSERT INTO justforfun (id, description, not_used) VALUES (5, 'fift', NULL);
 INSERT INTO justforfun (id, description) VALUES (6, 'sixt');
 INSERT INTO justforfun (id, description) VALUES (7, 'seventh');
-INSERT INTO justforfun (id, description, not_used) VALUES (8, 'eight', 800);
+INSERT INTO justforfun (id, description, not_used) VALUES (8, 'eight', 'meh8');
 INSERT INTO justforfun (id, description) VALUES (9, 'ninth');
 INSERT INTO justforfun (id, description) VALUES (10, 'tenth');


### PR DESCRIPTION
sql.Scan sucks at assigning `nil` to pointers potentially typed nil issues? who knows, I just wrap pointer fields for string and time (most common nullable) to a sane Scanner