### PR TITLE
Handle NULL for non ptr string and time

### DIFF
--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -208,7 +208,7 @@ func testConnector_QueryReflection(t *testing.T, newDB NewDB) {
 	type row struct {
 		Id          int
 		Description string
-		NotUsed     *string
+		NotUsed     string
 		NotUsedTime *time.Time
 	}
 
@@ -267,12 +267,12 @@ func testConnector_QueryReflection(t *testing.T, newDB NewDB) {
 			t.FailNow()
 		}
 		if nu, ok := expectedNotUsed[i]; ok {
-			if oneRowMulti.NotUsed == nil {
-				t.Logf("expected NotUsed value, got nil")
+			if oneRowMulti.NotUsed == "" {
+				t.Logf("expected NotUsed value, got empty")
 				t.FailNow()
 			}
-			if *oneRowMulti.NotUsed != nu {
-				t.Logf("expected NotUsed value to be %s but is %s", nu, *oneRowMulti.NotUsed)
+			if oneRowMulti.NotUsed != nu {
+				t.Logf("expected NotUsed value to be %s but is %s", nu, oneRowMulti.NotUsed)
 				t.FailNow()
 			}
 		}

--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -209,7 +209,7 @@ func testConnector_QueryReflection(t *testing.T, newDB NewDB) {
 		Id          int
 		Description string
 		NotUsed     string
-		NotUsedTime *time.Time
+		NotUsedTime time.Time
 	}
 
 	// Test Multiple row Iterator
@@ -245,6 +245,11 @@ func testConnector_QueryReflection(t *testing.T, newDB NewDB) {
 		2: "meh",
 		8: "meh8",
 	}
+
+	tTest, _ := time.Parse("2006-01-02", "1985-10-26") // the day marty goes back to the past
+	expectedNotUsedTime := map[int]time.Time{
+		10: tTest,
+	}
 	err = fetcher(&multiRow)
 	if err != nil {
 		t.Errorf("failed to fetch data: %v", err)
@@ -273,6 +278,17 @@ func testConnector_QueryReflection(t *testing.T, newDB NewDB) {
 			}
 			if oneRowMulti.NotUsed != nu {
 				t.Logf("expected NotUsed value to be %s but is %s", nu, oneRowMulti.NotUsed)
+				t.FailNow()
+			}
+		}
+		if nud, ok := expectedNotUsedTime[i]; ok {
+			noTime := time.Time{}
+			if oneRowMulti.NotUsedTime == noTime {
+				t.Logf("expected NotUsedTime value, got empty")
+				t.FailNow()
+			}
+			if oneRowMulti.NotUsedTime.Year() != nud.Year() || oneRowMulti.NotUsedTime.Month() != nud.Month() || oneRowMulti.NotUsedTime.Day() != nud.Day() {
+				t.Logf("got date %v but expected %v", nud, oneRowMulti.NotUsedTime)
 				t.FailNow()
 			}
 		}

--- a/db/srm/reflection.go
+++ b/db/srm/reflection.go
@@ -241,7 +241,7 @@ type nullScanner struct {
 }
 
 // Scan implements Scanner interface for strings and Time structs and adds special handling for
-// nill cases when the receiver struct member is not a pointer (notice that reflection here
+// nil cases when the receiver struct member is not a pointer (notice that reflection here
 // passes a pointer to the original member hence the double pointers for cases where it is
 // a pointer)
 func (ns *nullScanner) Scan(src interface{}) error {

--- a/initial.sql
+++ b/initial.sql
@@ -8,4 +8,4 @@ INSERT INTO justforfun (id, description) VALUES (6, 'sixt');
 INSERT INTO justforfun (id, description) VALUES (7, 'seventh');
 INSERT INTO justforfun (id, description, not_used) VALUES (8, 'eight', 'meh8');
 INSERT INTO justforfun (id, description) VALUES (9, 'ninth');
-INSERT INTO justforfun (id, description) VALUES (10, 'tenth');
+INSERT INTO justforfun (id, description, not_used_time) VALUES (10, 'tenth', to_date('1985-10-26', 'YYYY-MM-DD'));


### PR DESCRIPTION
Handle cases where the receiver is not a pointer in certain types (when member of struct is `string` or `time.Time` we just set up zero value when the incoming column is `NULL` instead of failing.

This is an opinionated change but not a breaking one.