### PR TITLE
Fix format string.

### DIFF
--- a/db/postgres/connection.go
+++ b/db/postgres/connection.go
@@ -481,7 +481,7 @@ func (d *DB) exec(statement string, args ...interface{}) (pgx.CommandTag, error)
 		}
 	}
 	if err != nil {
-		return connTag, errors.Wrapf(err, "querying database, obtained %s", connTag)
+		return connTag, errors.Wrapf(err, "querying database, obtained %v", connTag)
 	}
 	return connTag, nil
 }

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -488,7 +488,7 @@ func (d *DB) exec(statement string, args ...interface{}) (sql.Result, error) {
 		}
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "querying database, obtained %s", connTag)
+		return nil, errors.Wrapf(err, "querying database, obtained %v", connTag)
 	}
 	return connTag, nil
 }


### PR DESCRIPTION
Argument is not a string; without the output looks like `... querying database, obtained %!s(<nil>): conn is dead`,
with it more like `... querying database, obtained <nil>: conn is dead`.