### PR TITLE
Correct update to use from instead of join

### DIFF
--- a/db/chain/chain_test.go
+++ b/db/chain/chain_test.go
@@ -348,9 +348,10 @@ func TestExpressionChain_Render(t *testing.T) {
 				AndWhere("field1 > ?", 1).
 				AndWhere("field2 = ?", 2).
 				AndWhere("field3 > ?", "pajarito").
-				Join("another_convenient_table", "pirulo = ?", "unpirulo"),
-			want:     "UPDATE convenient_table SET field1 = $1, field3 = $2 JOIN another_convenient_table ON pirulo = $3 WHERE field1 > $4 AND field2 = $5 AND field3 > $6",
-			wantArgs: []interface{}{"value2", 9, "unpirulo", 1, 2, "pajarito"},
+				AndWhere("pirulo = ?", "unpirulo").
+				FromUpdate("another_convenient_table"),
+			want:     "UPDATE convenient_table SET field1 = $1, field3 = $2 FROM another_convenient_table WHERE field1 > $3 AND field2 = $4 AND field3 > $5 AND pirulo = $6",
+			wantArgs: []interface{}{"value2", 9, 1, 2, "pajarito", "unpirulo"},
 			wantErr:  false,
 		},
 		{
@@ -379,9 +380,10 @@ func TestExpressionChain_Render(t *testing.T) {
 				AndWhere("field1 > ?", 1).
 				AndWhere("field2 = ?", 2).
 				AndWhere("field3 > ?", "pajarito").
-				Join("another_convenient_table", "pirulo = ?", "unpirulo"),
-			want:     "UPDATE convenient_table SET field1 = $1, field3 = NULL JOIN another_convenient_table ON pirulo = $2 WHERE field1 > $3 AND field2 = $4 AND field3 > $5",
-			wantArgs: []interface{}{"value2", "unpirulo", 1, 2, "pajarito"},
+				AndWhere("pirulo = ?", "unpirulo").
+				FromUpdate("another_convenient_table"),
+			want:     "UPDATE convenient_table SET field1 = $1, field3 = NULL FROM another_convenient_table WHERE field1 > $2 AND field2 = $3 AND field3 > $4 AND pirulo = $5",
+			wantArgs: []interface{}{"value2", 1, 2, "pajarito", "unpirulo"},
 			wantErr:  false,
 		},
 		{
@@ -391,9 +393,10 @@ func TestExpressionChain_Render(t *testing.T) {
 				AndWhere("field1 > ?", 1).
 				AndWhere("field2 = ?", 2).
 				AndWhere("field3 > ?", "pajarito").
-				Join("another_convenient_table", "pirulo = ?", "unpirulo"),
-			want:     "UPDATE convenient_table SET field1 = $1, field3 = $2 JOIN another_convenient_table ON pirulo = $3 WHERE field1 > $4 AND field2 = $5 AND field3 > $6",
-			wantArgs: []interface{}{"value2", 9, "unpirulo", 1, 2, "pajarito"},
+				AndWhere("pirulo = ?", "unpirulo").
+				FromUpdate("another_convenient_table"),
+			want:     "UPDATE convenient_table SET field1 = $1, field3 = $2 FROM another_convenient_table WHERE field1 > $3 AND field2 = $4 AND field3 > $5 AND pirulo = $6",
+			wantArgs: []interface{}{"value2", 9, 1, 2, "pajarito", "unpirulo"},
 			wantErr:  false,
 		},
 		{

--- a/db/chain/expressions.go
+++ b/db/chain/expressions.go
@@ -61,10 +61,10 @@ func (ec *ExpressionChain) appendExpandedOp(expr string,
 	expr, args = ExpandArgs(args, expr)
 	ec.append(
 		querySegmentAtom{
-			segment:   op,
+			segment:    op,
 			expression: ec.populateTablePrefixes(expr),
-			arguments: args,
-			sqlBool:   boolOp,
+			arguments:  args,
+			sqlBool:    boolOp,
 		})
 	return ec
 }
@@ -75,10 +75,10 @@ func (ec *ExpressionChain) setExpandedMainOp(expr string,
 	args ...interface{}) *ExpressionChain {
 	expr, args = ExpandArgs(args, expr)
 	ec.mainOperation = &querySegmentAtom{
-		segment:   op,
+		segment:    op,
 		expression: ec.populateTablePrefixes(expr),
-		arguments: args,
-		sqlBool:   boolOp,
+		arguments:  args,
+		sqlBool:    boolOp,
 	}
 	return ec
 }
@@ -137,7 +137,7 @@ func (ec *ExpressionChain) Returning(args ...string) *ExpressionChain {
 	}
 	ec.append(
 		querySegmentAtom{
-			segment:   sqlReturning,
+			segment:    sqlReturning,
 			expression: "RETURNING " + strings.Join(args, ", "),
 		})
 	return ec
@@ -159,16 +159,22 @@ func (ec *ExpressionChain) From(table string) *ExpressionChain {
 	return ec
 }
 
+// FromUpdate adds a special case of from, for UPDATE where FROM is used as JOIN
+func (ec *ExpressionChain) FromUpdate(expr string, args ...interface{}) *ExpressionChain {
+	ec.appendExpandedOp(expr, sqlFromUpdate, SQLNothing, args...)
+	return ec
+}
+
 // Limit adds a 'LIMIT' to the 'ExpressionChain' and returns the same chan to facilitate
 // further chaining.
 // THIS DOES NOT CREATE A COPY OF THE CHAIN, IT MUTATES IN PLACE.
 func (ec *ExpressionChain) Limit(limit int64) *ExpressionChain {
 	ec.setLimit(
 		&querySegmentAtom{
-			segment:   sqlLimit,
+			segment:    sqlLimit,
 			expression: strconv.FormatInt(limit, 10),
-			arguments: nil,
-			sqlBool:   SQLNothing,
+			arguments:  nil,
+			sqlBool:    SQLNothing,
 		})
 	return ec
 }
@@ -179,10 +185,10 @@ func (ec *ExpressionChain) Limit(limit int64) *ExpressionChain {
 func (ec *ExpressionChain) Offset(offset int64) *ExpressionChain {
 	ec.setOffset(
 		&querySegmentAtom{
-			segment:   sqlOffset,
+			segment:    sqlOffset,
 			expression: strconv.FormatInt(offset, 10),
-			arguments: nil,
-			sqlBool:   SQLNothing,
+			arguments:  nil,
+			sqlBool:    SQLNothing,
 		})
 	return ec
 }
@@ -270,9 +276,9 @@ func (ec *ExpressionChain) AddUnionFromChain(union *ExpressionChain, all bool) (
 // change is in place, there are no checks about correctness of the query.
 func (ec *ExpressionChain) Union(unionExpr string, all bool, args ...interface{}) *ExpressionChain {
 	atom := querySegmentAtom{
-		segment:   sqlUnion,
+		segment:    sqlUnion,
 		expression: ec.populateTablePrefixes(unionExpr),
-		arguments: args,
+		arguments:  args,
 	}
 	if all {
 		atom.sqlModifier = SQLAll

--- a/db/chain/rendering.go
+++ b/db/chain/rendering.go
@@ -187,8 +187,7 @@ func (ec *ExpressionChain) render(raw bool, query *strings.Builder) ([]interface
 
 	}
 	if ec.mainOperation.segment == sqlSelect ||
-		ec.mainOperation.segment == sqlDelete ||
-		ec.mainOperation.segment == sqlUpdate {
+		ec.mainOperation.segment == sqlDelete {
 		// JOIN
 		joins := extract(ec, sqlJoin)
 		joins = append(joins, extract(ec, sqlLeftJoin)...)
@@ -202,6 +201,22 @@ func (ec *ExpressionChain) render(raw bool, query *strings.Builder) ([]interface
 				query.WriteRune(' ')
 				query.WriteString(join.expression)
 				args = append(args, join.arguments...)
+			}
+		}
+	}
+	if ec.mainOperation.segment == sqlUpdate {
+		// In UPDATE join is accomplished by using the FROM clause because why would this be
+		// easy?
+		froms := extract(ec, sqlFromUpdate)
+
+		if len(froms) != 0 {
+			query.WriteString(" FROM ")
+			for i, from := range froms {
+				if i != 0 {
+					query.WriteString(", ")
+				}
+				query.WriteString(from.expression)
+				args = append(args, from.arguments...)
 			}
 		}
 	}

--- a/db/chain/segment.go
+++ b/db/chain/segment.go
@@ -48,23 +48,24 @@ const (
 type sqlSegment string
 
 const (
-	sqlWhere     sqlSegment = "WHERE"
-	sqlLimit     sqlSegment = "LIMIT"
-	sqlOffset    sqlSegment = "OFFSET"
-	sqlJoin      sqlSegment = "JOIN"
-	sqlLeftJoin  sqlSegment = "LEFT JOIN"
-	sqlRightJoin sqlSegment = "RIGHT JOIN"
-	sqlInnerJoin sqlSegment = "INNER JOIN"
-	sqlFullJoin  sqlSegment = "FULL JOIN"
-	sqlSelect    sqlSegment = "SELECT"
-	sqlDelete    sqlSegment = "DELETE"
-	sqlInsert    sqlSegment = "INSERT"
-	sqlUpdate    sqlSegment = "UPDATE"
-	sqlFrom      sqlSegment = "FROM"
-	sqlGroup     sqlSegment = "GROUP BY"
-	sqlOrder     sqlSegment = "ORDER BY"
-	sqlReturning sqlSegment = "RETURNING"
-	sqlHaving    sqlSegment = "HAVING"
+	sqlWhere      sqlSegment = "WHERE"
+	sqlLimit      sqlSegment = "LIMIT"
+	sqlOffset     sqlSegment = "OFFSET"
+	sqlJoin       sqlSegment = "JOIN"
+	sqlLeftJoin   sqlSegment = "LEFT JOIN"
+	sqlRightJoin  sqlSegment = "RIGHT JOIN"
+	sqlInnerJoin  sqlSegment = "INNER JOIN"
+	sqlFullJoin   sqlSegment = "FULL JOIN"
+	sqlSelect     sqlSegment = "SELECT"
+	sqlDelete     sqlSegment = "DELETE"
+	sqlInsert     sqlSegment = "INSERT"
+	sqlUpdate     sqlSegment = "UPDATE"
+	sqlFrom       sqlSegment = "FROM"
+	sqlFromUpdate sqlSegment = "FROM"
+	sqlGroup      sqlSegment = "GROUP BY"
+	sqlOrder      sqlSegment = "ORDER BY"
+	sqlReturning  sqlSegment = "RETURNING"
+	sqlHaving     sqlSegment = "HAVING"
 	// SPECIAL CASES
 	sqlInsertMulti sqlSegment = "INSERTM"
 	sqlUnion                  = "UNION"
@@ -72,7 +73,7 @@ const (
 
 type querySegmentAtom struct {
 	segment     sqlSegment
-	expression   string
+	expression  string
 	arguments   []interface{}
 	sqlBool     sqlBool
 	sqlModifier sqlModifier
@@ -86,10 +87,10 @@ func (q *querySegmentAtom) clone() querySegmentAtom {
 		arguments[i] = a
 	}
 	return querySegmentAtom{
-		segment:   q.segment,
+		segment:    q.segment,
 		expression: q.expression,
-		sqlBool:   q.sqlBool,
-		arguments: arguments,
+		sqlBool:    q.sqlBool,
+		arguments:  arguments,
 	}
 }
 


### PR DESCRIPTION
Turns out that update uses FROM to enact JOIN as indicated in the https://www.postgresql.org/docs/9.1/sql-update.html `from_list` parameter