### PR TITLE
Horacio/support double indirection in receiver

### DIFF
--- a/db/connection_testing/connection_testing.go
+++ b/db/connection_testing/connection_testing.go
@@ -359,6 +359,36 @@ func testConnector_Query(t *testing.T, newDB NewDB) {
 		}
 
 	}
+	// same with slice of ptr receiver
+	var multiRowPtr []*row
+
+	fetcher, err = query.Query()
+	if err != nil {
+		t.Errorf("failed to query: %v", err)
+	}
+	err = fetcher(&multiRowPtr)
+	if err != nil {
+		t.Errorf("failed to fetch data: %v", err)
+	}
+
+	if len(multiRowPtr) != 10 {
+		t.Logf("expected 10 results got %d", len(multiRowPtr))
+		t.FailNow()
+	}
+	for i := 1; i < 11; i++ {
+		t.Logf("Iteration %d", i)
+		oneRowMulti := multiRowPtr[i-1]
+
+		if oneRowMulti.Id != i {
+			t.Logf("row Id is %d expected 1", oneRowMulti.Id)
+			t.FailNow()
+		}
+		if oneRowMulti.Description != ordinals[i-1] {
+			t.Logf("row Description is %q expected %q", oneRowMulti.Description, ordinals[i-1])
+			t.FailNow()
+		}
+
+	}
 
 }
 

--- a/db/postgres/connection.go
+++ b/db/postgres/connection.go
@@ -356,7 +356,7 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 			// Get a New ptr to the object of the type of the slice.
 			newElemPtr := reflect.New(tod)
 			// Get the concrete object
-			newElem := newElemPtr.Elem()
+			newElem := newElemPtr.Elem().Elem() // 2nd elem in case type is ptr
 			// Get it's type.
 			ttod := newElem.Type()
 

--- a/db/postgres/connection.go
+++ b/db/postgres/connection.go
@@ -356,13 +356,29 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 			// Get a New ptr to the object of the type of the slice.
 			newElemPtr := reflect.New(tod)
 			// Get the concrete object
-			newElem := newElemPtr.Elem().Elem() // 2nd elem in case type is ptr
+			var newElem reflect.Value
+			var newElemType reflect.Type
+			if tod.Kind() == reflect.Ptr {
+				// Handle slice of pointer
+				intermediatePtr := newElemPtr.Elem()
+				concrete := tod.Elem()
+				newElemType = concrete
+				// this will most likely always be the case, but let's be defensive
+				if intermediatePtr.IsNil() {
+					concreteInstancePtr := reflect.New(concrete)
+					intermediatePtr.Set(concreteInstancePtr)
+				}
+				newElem = intermediatePtr.Elem()
+			} else {
+				newElemType = newElemPtr.Elem().Type()
+				newElem = newElemPtr.Elem()
+			}
 			// Get it's type.
 			ttod := newElem.Type()
 
 			// map the fields of the type to their potential sql names, this is the only "magic"
 			fieldMap = make(map[string]reflect.StructField, ttod.NumField())
-			_, fieldMap, err = srm.MapFromTypeOf(newElemPtr.Elem().Type(),
+			_, fieldMap, err = srm.MapFromTypeOf(newElemType,
 				[]reflect.Kind{}, []reflect.Kind{
 					reflect.Map, reflect.Slice,
 				})

--- a/db/postgrespq/connection.go
+++ b/db/postgrespq/connection.go
@@ -361,7 +361,7 @@ func (d *DB) Query(statement string, fields []string, args ...interface{}) (conn
 			// Get a New ptr to the object of the type of the slice.
 			newElemPtr := reflect.New(tod)
 			// Get the concrete object
-			newElem := newElemPtr.Elem()
+			newElem := newElemPtr.Elem().Elem() // 2nd elem in case type is ptr
 			// Get it's type.
 			ttod := newElem.Type()
 


### PR DESCRIPTION
Receiving slice of pointers requires some extra processing, namely dealing with double instantiation (actually instantiate the underlying type then de-reference) as reflect is not smart enough to do this.
We were creating nil pointers for the case where we received slice of pointer and therefore scanner/valuer was not working for these, now we do the instantiation up to one level (no ptr of ptr)