### PR TITLE
Support escaped '?', which may be JSONB operators

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Horacio Duran <horacio@shiftleft.io>
 William Cody Laeder <cody@shiftleft.io>
 Alex Hornbake <alex@shiftleft.io>
+Preetam Jinka <preetam@shiftleft.io>

--- a/db/chain/placeholders_test.go
+++ b/db/chain/placeholders_test.go
@@ -1,6 +1,9 @@
 package chain
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func Test_digitSize(t *testing.T) {
 	type args struct {
@@ -52,6 +55,48 @@ func Test_digitSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := digitSize(tt.args.argLen); got != tt.want {
 				t.Errorf("digitSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlaceholderEscaping(t *testing.T) {
+	tests := []struct {
+		q    string
+		want string
+		args []interface{}
+	}{
+		{
+			q:    "? = 1",
+			want: "$1 = 1",
+			args: []interface{}{1},
+		},
+		{
+			q:    "\\? = 1",
+			want: "? = 1",
+			args: []interface{}{},
+		},
+		{
+			q:    "? = ? AND \\? = 1",
+			want: "$1 = $2 AND ? = 1",
+			args: []interface{}{1, 1},
+		},
+		{
+			q:    `'["a", "b"]'::jsonb \?& array['a', 'b']`,
+			want: `'["a", "b"]'::jsonb ?& array['a', 'b']`,
+			args: []interface{}{},
+		},
+		{
+			q:    `'["a", "b"]'::jsonb \?& array[?]`,
+			want: `'["a", "b"]'::jsonb ?& array[$1]`,
+			args: []interface{}{"a"},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			result, _, _ := MarksToPlaceholders(tt.q, tt.args)
+			if result != tt.want {
+				t.Errorf("got %v, want %v", result, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
`?`, `?|`, and `?&` are JSONB operators, so we need to be able to skip over escaped `?`

https://www.postgresql.org/docs/9.6/functions-json.html