### PR TITLE
db/chain: OnUpdate.SetSQLWithArgs to pass args on conflict

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Horacio Duran <horacio@shiftleft.io>
 William Cody Laeder <cody@shiftleft.io>
 Alex Hornbake <alex@shiftleft.io>
 Preetam Jinka <preetam@shiftleft.io>
+John Lenton <jlenton@shiftleft.io>

--- a/db/chain/constraint.go
+++ b/db/chain/constraint.go
@@ -127,6 +127,21 @@ func (o *OnUpdate) SetSQL(args ...string) *OnUpdate {
 	return o
 }
 
+// SetSQLWithArgs sets a field to a value that itself needs no
+// escaping but may contain placeholders, to be filled with the
+// optional args.
+//
+// This is useful to build tings like `SET foo = foo || 'bar'` with
+// the appropriate escaping.
+func (o *OnUpdate) SetSQLWithArgs(column, sql string, args ...interface{}) *OnUpdate {
+	*o.operatorList = append(*o.operatorList, argList{
+		text: "(" + column + ") = (" + sql + ")",
+		data: args,
+	})
+
+	return o
+}
+
 // SetSQLNoParens Sets a field to a value that needs no escaping, it is assumed to be SQL valid (an
 // expression or column) and doesn't insert any parentheses around either keys or values
 func (o *OnUpdate) SetSQLNoParens(args ...string) *OnUpdate {


### PR DESCRIPTION
This enables building SQL that has things like

    ... ON CONFLICT ... DO UPDATE SET (foo) = (foo || $n)

which is nice.