### PR TITLE
Go modules uses questionable versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/ShiftLeftSecurity/gaum
+module github.com/ShiftLeftSecurity/gaum/v2
 
-go 1.12
+go 1.15
 
 require (
 	github.com/cockroachdb/apd v1.1.0 // indirect


### PR DESCRIPTION
So we need to update our path, if only there was a way to specify a vMajor.Minor.Patch version in metadata.
Also bumped go version to what we really use