### PR TITLE
Remove non-effective settings in postgrespq/connection.go

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ William Cody Laeder <cody@shiftleft.io>
 Alex Hornbake <alex@shiftleft.io>
 Preetam Jinka <preetam@shiftleft.io>
 John Lenton <jlenton@shiftleft.io>
+Michał Sitko <msitko@shiftleft.io>


### PR DESCRIPTION
E.g. `config.MaxConns = DefaultPGPoolMaxConn` was not effective because `config` is never passed anywhere else

Ideally postgrespq should use a different data type than `connection.Information` as it's quite misleading to accept configuration that is not applied but I would leave it for another PR. Now it will be clear, at least after looking at the implementation, which values are used and which not